### PR TITLE
Add linting and formatting

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,25 @@
+module.exports = {
+  env: {
+    browser: true,
+    es2021: true,
+    node: true
+  },
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint', 'astro', 'prettier'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:astro/recommended',
+    'plugin:prettier/recommended'
+  ],
+  overrides: [
+    {
+      files: ['*.astro'],
+      parser: 'astro-eslint-parser',
+      parserOptions: {
+        parser: '@typescript-eslint/parser'
+      }
+    }
+  ],
+  rules: {}
+};

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+node_modules
+/dist
+/.astro

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "singleQuote": true,
+  "semi": true,
+  "trailingComma": "es5",
+  "printWidth": 100,
+  "plugins": ["prettier-plugin-astro", "prettier-plugin-tailwindcss"]
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
-    "preview": "astro preview"
+    "preview": "astro preview",
+    "format": "prettier . --write",
+    "lint": "eslint --config .eslintrc.cjs .",
+    "lint:fix": "eslint --config .eslintrc.cjs . --fix"
   },
   "dependencies": {
     "astro": "^4.0.0",
@@ -15,6 +18,16 @@
     "tailwindcss": "^3.0.0",
     "autoprefixer": "^10.0.0",
     "postcss": "^8.0.0",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "prettier": "^3.0.0",
+    "prettier-plugin-astro": "^0.12.0",
+    "prettier-plugin-tailwindcss": "^0.2.0",
+    "eslint": "^9.0.0",
+    "eslint-config-prettier": "^9.0.0",
+    "eslint-plugin-prettier": "^5.0.0",
+    "eslint-plugin-astro": "^0.30.0",
+    "astro-eslint-parser": "^0.3.0",
+    "@typescript-eslint/eslint-plugin": "^6.0.0",
+    "@typescript-eslint/parser": "^6.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- add eslint config with Astro and TypeScript support
- configure prettier with Tailwind and Astro plugins
- add scripts for `npm run format` and linting
- list related devDependencies

## Testing
- `npm run lint` *(fails: cannot find @typescript-eslint/eslint-plugin)*