### PR TITLE
Add blog and CV pages

### DIFF
--- a/public/cv.pdf
+++ b/public/cv.pdf
@@ -1,0 +1,1 @@
+PDF placeholder

--- a/src/content/blog/2025-05-20-welcome.md
+++ b/src/content/blog/2025-05-20-welcome.md
@@ -1,0 +1,7 @@
+---
+title: Welcome Post
+pubDate: 2025-05-20
+description: A quick introduction to the new blog.
+---
+
+This is the first post on the blog.

--- a/src/content/blog/2025-05-21-second-entry.md
+++ b/src/content/blog/2025-05-21-second-entry.md
@@ -1,0 +1,7 @@
+---
+title: Second Entry
+pubDate: 2025-05-21
+description: Continuing the journey.
+---
+
+More content in the second post.

--- a/src/content/cv/education.md
+++ b/src/content/cv/education.md
@@ -1,0 +1,7 @@
+---
+title: Education
+order: 2
+date: 2015-2020
+---
+
+Information about your education.

--- a/src/content/cv/experience.md
+++ b/src/content/cv/experience.md
@@ -1,0 +1,7 @@
+---
+title: Experience
+order: 1
+date: 2020-2025
+---
+
+Details about your work experience.

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,5 +1,11 @@
 ---
-const { title } = Astro.props;
+import '../styles/global.css';
+
+export interface Props {
+  title: string;
+}
+
+const { title } = Astro.props as Props;
 ---
 
 <!doctype html>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,0 +1,25 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import { getCollection, getEntryBySlug } from 'astro:content';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('blog');
+  return posts.map(post => ({ params: { slug: post.slug } }));
+}
+
+const { slug } = Astro.params;
+const post = await getEntryBySlug('blog', slug);
+if (!post) {
+  throw new Error(`Post not found: ${slug}`);
+}
+const { Content } = await post.render();
+const { data } = post;
+---
+
+<Layout title={data.title}>
+  <article class="prose mx-auto px-4 py-8">
+    <h1 class="mb-2 text-4xl font-bold">{data.title}</h1>
+    <p class="mb-8 text-sm text-gray-500">{data.pubDate.toLocaleDateString()}</p>
+    <Content />
+  </article>
+</Layout>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,0 +1,32 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import { getCollection } from 'astro:content';
+
+const posts = await getCollection('blog');
+const sorted = posts.sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
+---
+
+<Layout title="Blog">
+  <main class="mx-auto max-w-3xl px-4 py-8">
+    <h1 class="mb-6 text-center text-3xl font-bold">Blog</h1>
+    <ul class="space-y-6">
+      {
+        sorted.map(post => (
+          <li
+            key={post.slug}
+            class="border-b pb-4"
+          >
+            <a
+              href={`/blog/${post.slug}/`}
+              class="text-xl font-semibold text-blue-600 hover:underline"
+            >
+              {post.data.title}
+            </a>
+            <p class="text-sm text-gray-500">{post.data.pubDate.toLocaleDateString()}</p>
+            {post.data.description && <p class="mt-2">{post.data.description}</p>}
+          </li>
+        ))
+      }
+    </ul>
+  </main>
+</Layout>

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -1,0 +1,38 @@
+---
+import Layout from '../layouts/Layout.astro';
+import { getCollection } from 'astro:content';
+
+const sections = await getCollection('cv');
+const sortedSections = sections.sort((a, b) => a.data.order - b.data.order);
+const rendered = await Promise.all(
+  sortedSections.map(async s => {
+    const { Content } = await s.render();
+    return { ...s, Content };
+  }),
+);
+---
+
+<Layout title="CV">
+  <main class="mx-auto max-w-3xl px-4 py-8">
+    <h1 class="mb-6 text-center text-3xl font-bold">Curriculum Vitae</h1>
+    <a
+      href="/cv.pdf"
+      download
+      class="mb-8 inline-block rounded bg-blue-600 px-4 py-2 font-medium text-white"
+      >Download PDF</a
+    >
+    <div class="space-y-8">
+      {
+        rendered.map(section => (
+          <section
+            id={section.slug}
+            key={section.slug}
+          >
+            <h2 class="mb-2 text-2xl font-semibold">{section.data.title}</h2>
+            <section.Content />
+          </section>
+        ))
+      }
+    </div>
+  </main>
+</Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,6 +3,29 @@ import Layout from '../layouts/Layout.astro';
 ---
 
 <Layout title="Home">
-  <h1 class="mb-4 text-3xl font-bold">Welcome</h1>
-  <p>This is my new Astro site.</p>
+  <main class="mx-auto max-w-3xl px-4 py-12 text-center">
+    <div class="mx-auto mb-6 h-32 w-32 rounded-full bg-gray-300"></div>
+    <h1 class="mb-2 text-4xl font-bold">Your Name</h1>
+    <p class="mb-8 text-lg text-gray-600">
+      Briefly introduce yourself here. Mention your profession and interests so visitors know what you're about.
+    </p>
+    <div class="flex flex-col items-center space-y-4 sm:flex-row sm:justify-center sm:space-x-4 sm:space-y-0">
+      <a
+        href="/cv"
+        class="rounded bg-blue-600 px-4 py-2 font-medium text-white"
+        >View CV</a
+      >
+      <a
+        href="/cv.pdf"
+        download
+        class="rounded border border-blue-600 px-4 py-2 font-medium text-blue-600"
+        >Download CV</a
+      >
+      <a
+        href="/blog"
+        class="rounded bg-green-600 px-4 py-2 font-medium text-white"
+        >Read Blog</a
+      >
+    </div>
+  </main>
 </Layout>


### PR DESCRIPTION
## Summary
- add blog post list and dynamic post page
- add CV page with sections and PDF download
- expand home page with intro text and links

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6830e7ddb6208326bb88442c6cf8dee6