### PR TITLE
feat: add Kniffel game and improve Wordle mobile support

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -54,7 +54,10 @@
       "Bash(jj show:*)",
       "Bash(jj cat:*)",
       "Bash(git show:*)",
-      "Bash(grep:*)"
+      "Bash(grep:*)",
+      "Bash(tree:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(gh api:*)"
     ]
   }
 }

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -1,0 +1,37 @@
+# Feature Ideas
+
+## Games
+
+- [ ] **Kniffel/Yahtzee Tracker** — Multiplayer score tracking with statistics
+- [ ] **Song Bingo** — Spotify OAuth integration for music bingo *(on hold: Spotify app creation unavailable)*
+- [ ] **Connections** — NYT-style word grouping puzzle (reuses Wordle UI patterns)
+- [ ] **Mini Crossword** — Small daily crossword with EN/DE support
+- [ ] **Number Guessing Game** — Mastermind-style code breaking
+- [ ] **Memory Match** — Card matching with themes
+
+## Interactive Tools
+
+- [ ] **Pomodoro Timer** — Productivity timer with stats
+- [ ] **QR Code Generator** — Utility tool
+- [ ] **Color Palette Generator** — Showcase the oklch color system
+- [ ] **Markdown Preview** — Live editor with MDX styling
+
+## Blog Enhancements
+
+- [ ] **Reading Time Estimates** — Show estimated read time on posts
+- [ ] **Table of Contents** — Auto-generated from MDX headings
+- [ ] **Series/Tags** — Group related posts together
+- [ ] **RSS Feed** — Standard blog syndication
+
+## Personal/Portfolio
+
+- [ ] **Now Page** — What you're currently working on/reading/playing
+- [ ] **Uses Page** — Your tech stack, tools, setup
+- [ ] **Project Showcase** — Highlight work with live demos
+- [ ] **Guestbook** — Retro web vibes, visitors can leave messages
+
+## Fun/Experimental
+
+- [ ] **Spotify Currently Playing** — Show what you're listening to *(on hold: Spotify app creation unavailable)*
+- [ ] **GitHub Activity Widget** — Recent commits visualization
+- [ ] **AI Chat Widget** — Chat with a "digital you" trained on blog posts

--- a/app/[locale]/games/kniffel/page.tsx
+++ b/app/[locale]/games/kniffel/page.tsx
@@ -1,12 +1,12 @@
 import Link from "next/link";
 import { getTranslations } from "next-intl/server";
-import { WordleGame } from "@/components/wordle";
+import { KniffelGame } from "@/components/kniffel";
 
-interface WordlePageProps {
+interface KniffelPageProps {
   params: Promise<{ locale: string }>;
 }
 
-export default async function WordlePage({ params }: WordlePageProps) {
+export default async function KniffelPage({ params }: KniffelPageProps) {
   const { locale } = await params;
   const t = await getTranslations("games");
 
@@ -20,11 +20,11 @@ export default async function WordlePage({ params }: WordlePageProps) {
           ← {locale === "de" ? "zurück" : "back"}
         </Link>
       </div>
-      <h1 className="text-2xl font-bold">{t("wordle.title")}</h1>
+      <h1 className="text-2xl font-bold">{t("kniffel.title")}</h1>
       <p className="text-muted-foreground text-center max-w-md">
-        {t("wordle.instructions")}
+        {t("kniffel.instructions")}
       </p>
-      <WordleGame locale={locale} />
+      <KniffelGame locale={locale} />
     </div>
   );
 }

--- a/app/[locale]/games/page.tsx
+++ b/app/[locale]/games/page.tsx
@@ -17,13 +17,25 @@ export default async function GamesPage({
         <p className="text-muted-foreground">{t("subtitle")}</p>
       </div>
 
-      <div className="rounded-2xl border border-border bg-card/60 p-4 shadow-sm">
-        <div className="space-y-3">
-          <h2 className="text-xl font-semibold">{t("wordle.title")}</h2>
-          <p className="text-muted-foreground">{t("wordle.description")}</p>
-          <Button asChild>
-            <Link href={`/${locale}/games/wordle`}>{t("wordle.play")}</Link>
-          </Button>
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="rounded-2xl border border-border bg-card/60 p-4 shadow-sm">
+          <div className="space-y-3">
+            <h2 className="text-xl font-semibold">{t("wordle.title")}</h2>
+            <p className="text-muted-foreground">{t("wordle.description")}</p>
+            <Button asChild>
+              <Link href={`/${locale}/games/wordle`}>{t("wordle.play")}</Link>
+            </Button>
+          </div>
+        </div>
+
+        <div className="rounded-2xl border border-border bg-card/60 p-4 shadow-sm">
+          <div className="space-y-3">
+            <h2 className="text-xl font-semibold">{t("kniffel.title")}</h2>
+            <p className="text-muted-foreground">{t("kniffel.description")}</p>
+            <Button asChild>
+              <Link href={`/${locale}/games/kniffel`}>{t("kniffel.play")}</Link>
+            </Button>
+          </div>
         </div>
       </div>
     </div>

--- a/app/[locale]/games/wordle/solver/page.tsx
+++ b/app/[locale]/games/wordle/solver/page.tsx
@@ -1,15 +1,16 @@
 "use client";
 
-import { RotateCcw } from "lucide-react";
+import { Keyboard, RotateCcw } from "lucide-react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   SolverInputGrid,
   useSolverInput,
 } from "@/components/wordle/solver/solver-input-grid";
 import { SolverSuggestions } from "@/components/wordle/solver/solver-suggestions";
+import { WordleKeyboard } from "@/components/wordle/wordle-keyboard";
 import { WORDS_DE, WORDS_EN } from "@/lib/wordle";
 import {
   createSolverState,
@@ -22,6 +23,17 @@ export default function SolverPage() {
   const locale = (params.locale as string) || "en";
   const wordList = locale === "de" ? WORDS_DE : WORDS_EN;
   const isDE = locale === "de";
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const [showKeyboard, setShowKeyboard] = useState(() => {
+    if (typeof window === "undefined") return true;
+    const stored = localStorage.getItem("wordle-solver-show-keyboard");
+    return stored !== "false";
+  });
+
+  useEffect(() => {
+    localStorage.setItem("wordle-solver-show-keyboard", String(showKeyboard));
+  }, [showKeyboard]);
 
   const {
     rows,
@@ -33,6 +45,31 @@ export default function SolverPage() {
     getSubmittedGuesses,
     reset,
   } = useSolverInput();
+
+  const handleMobileInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    if (value.length > 0) {
+      const lastChar = value.at(-1);
+      if (lastChar && /^[a-zA-ZäöüÄÖÜ]$/.test(lastChar)) {
+        handleLetterInput(lastChar.toUpperCase());
+      }
+    }
+    e.target.value = "";
+  };
+
+  const handleMobileKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleSubmit();
+    } else if (e.key === "Backspace") {
+      e.preventDefault();
+      handleBackspace();
+    }
+  };
+
+  const focusInput = () => {
+    inputRef.current?.focus();
+  };
 
   // Calculate solver state from submitted guesses
   const { suggestions, possibleWordsCount } = useMemo(() => {
@@ -71,23 +108,67 @@ export default function SolverPage() {
           : "Get help solving any Wordle puzzle. Enter your guesses and get suggestions."}
       </p>
 
+      {/* Hidden input for mobile keyboard */}
+      <input
+        ref={inputRef}
+        type="text"
+        inputMode="text"
+        autoComplete="off"
+        autoCorrect="off"
+        autoCapitalize="off"
+        spellCheck={false}
+        className="sr-only"
+        onChange={handleMobileInput}
+        onKeyDown={handleMobileKeyDown}
+        aria-label="Type your guess"
+      />
+
       <div className="flex flex-col lg:flex-row gap-8 items-start">
         {/* Input grid */}
         <div className="flex flex-col items-center gap-4">
-          <SolverInputGrid
-            rows={rows}
-            currentRowIndex={currentRowIndex}
-            onTileClick={handleTileClick}
-            onLetterInput={handleLetterInput}
-            onBackspace={handleBackspace}
-            onSubmit={handleSubmit}
-            locale={locale}
-          />
+          <button
+            type="button"
+            onClick={focusInput}
+            className="focus:outline-none"
+            aria-label="Tap to type"
+          >
+            <SolverInputGrid
+              rows={rows}
+              currentRowIndex={currentRowIndex}
+              onTileClick={handleTileClick}
+              onLetterInput={handleLetterInput}
+              onBackspace={handleBackspace}
+              onSubmit={handleSubmit}
+              locale={locale}
+            />
+          </button>
 
-          <Button onClick={reset} variant="outline" className="gap-2">
-            <RotateCcw className="size-4" />
-            {isDE ? "Zurücksetzen" : "Reset"}
-          </Button>
+          <div className="flex gap-2">
+            <Button onClick={reset} variant="outline" className="gap-2">
+              <RotateCcw className="size-4" />
+              {isDE ? "Zurücksetzen" : "Reset"}
+            </Button>
+
+            <Button
+              variant={showKeyboard ? "secondary" : "ghost"}
+              size="icon"
+              onClick={() => setShowKeyboard(!showKeyboard)}
+              aria-label={showKeyboard ? "Hide keyboard" : "Show keyboard"}
+            >
+              <Keyboard className="size-4" />
+            </Button>
+          </div>
+
+          {/* On-screen keyboard */}
+          {showKeyboard && (
+            <WordleKeyboard
+              letterStates={{}}
+              onKey={handleLetterInput}
+              onEnter={handleSubmit}
+              onBackspace={handleBackspace}
+              locale={locale}
+            />
+          )}
         </div>
 
         {/* Suggestions */}

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -50,7 +50,7 @@ export function Header() {
   const locale = useLocale();
 
   return (
-    <header className="sticky top-0 z-50">
+    <header className="sticky top-0 z-50 bg-background">
       <div className="mx-auto flex h-14 max-w-3xl items-center justify-between px-4 sm:px-6">
         <Link
           href={`/${locale}`}

--- a/components/kniffel/index.ts
+++ b/components/kniffel/index.ts
@@ -1,0 +1,8 @@
+export { KniffelDice } from "./kniffel-dice";
+export { KniffelDie } from "./kniffel-die";
+export { KniffelGame } from "./kniffel-game";
+export { KniffelModeSelect } from "./kniffel-mode-select";
+export { KniffelPlayerSetup } from "./kniffel-player-setup";
+export { KniffelScoreInput } from "./kniffel-score-input";
+export { KniffelScorecard } from "./kniffel-scorecard";
+export { useKniffel } from "./use-kniffel";

--- a/components/kniffel/kniffel-dice.tsx
+++ b/components/kniffel/kniffel-dice.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { Dices } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type { DieState } from "@/lib/kniffel";
+import { KniffelDie } from "./kniffel-die";
+
+interface KniffelDiceProps {
+  dice: DieState[];
+  rollsRemaining: number;
+  hasRolled: boolean;
+  canRoll: boolean;
+  onRoll: () => void;
+  onToggleHold: (index: number) => void;
+  locale: string;
+  rolling?: boolean;
+}
+
+export function KniffelDice({
+  dice,
+  rollsRemaining,
+  hasRolled,
+  canRoll,
+  onRoll,
+  onToggleHold,
+  locale,
+  rolling = false,
+}: KniffelDiceProps) {
+  const rollText = locale === "de" ? "Würfeln" : "Roll";
+  const rollsText =
+    locale === "de"
+      ? `${rollsRemaining} ${rollsRemaining === 1 ? "Wurf" : "Würfe"} übrig`
+      : `${rollsRemaining} roll${rollsRemaining === 1 ? "" : "s"} left`;
+
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <div className="flex gap-2 sm:gap-3">
+        {dice.map((die, index) => (
+          <KniffelDie
+            // biome-ignore lint/suspicious/noArrayIndexKey: dice array is fixed length (5) and never reordered
+            key={index}
+            value={die.value}
+            held={die.held}
+            disabled={!hasRolled}
+            onClick={() => onToggleHold(index)}
+            rolling={rolling && !die.held}
+          />
+        ))}
+      </div>
+
+      <div className="flex flex-col items-center gap-2">
+        <Button onClick={onRoll} disabled={!canRoll} className="gap-2">
+          <Dices className="size-4" />
+          {rollText}
+        </Button>
+        <span className="text-sm text-muted-foreground">{rollsText}</span>
+      </div>
+    </div>
+  );
+}

--- a/components/kniffel/kniffel-die.tsx
+++ b/components/kniffel/kniffel-die.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const dieVariants = cva(
+  "relative flex items-center justify-center rounded-lg border-2 transition-all duration-200 select-none",
+  {
+    variants: {
+      state: {
+        default: "border-border bg-card hover:border-primary cursor-pointer",
+        held: "border-primary bg-primary/10 ring-2 ring-primary/30 cursor-pointer",
+        disabled: "border-muted bg-muted/50 cursor-default opacity-60",
+      },
+      size: {
+        default: "size-12 sm:size-14 text-xl sm:text-2xl",
+        small: "size-10 sm:size-12 text-lg sm:text-xl",
+      },
+    },
+    defaultVariants: {
+      state: "default",
+      size: "default",
+    },
+  },
+);
+
+interface KniffelDieProps extends VariantProps<typeof dieVariants> {
+  value: number;
+  held?: boolean;
+  disabled?: boolean;
+  onClick?: () => void;
+  className?: string;
+  rolling?: boolean;
+}
+
+const dotPositions: Record<number, number[][]> = {
+  1: [[50, 50]],
+  2: [
+    [25, 25],
+    [75, 75],
+  ],
+  3: [
+    [25, 25],
+    [50, 50],
+    [75, 75],
+  ],
+  4: [
+    [25, 25],
+    [75, 25],
+    [25, 75],
+    [75, 75],
+  ],
+  5: [
+    [25, 25],
+    [75, 25],
+    [50, 50],
+    [25, 75],
+    [75, 75],
+  ],
+  6: [
+    [25, 25],
+    [75, 25],
+    [25, 50],
+    [75, 50],
+    [25, 75],
+    [75, 75],
+  ],
+};
+
+export function KniffelDie({
+  value,
+  held = false,
+  disabled = false,
+  onClick,
+  size,
+  className,
+  rolling = false,
+}: KniffelDieProps) {
+  const state = disabled ? "disabled" : held ? "held" : "default";
+  const dots = dotPositions[value] || [];
+
+  return (
+    <button
+      type="button"
+      onClick={disabled ? undefined : onClick}
+      disabled={disabled}
+      className={cn(
+        dieVariants({ state, size, className }),
+        rolling && "animate-pulse",
+      )}
+      aria-label={`Die showing ${value}${held ? ", held" : ""}`}
+    >
+      <svg
+        viewBox="0 0 100 100"
+        className="w-full h-full p-2"
+        aria-hidden="true"
+      >
+        {dots.map(([cx, cy]) => (
+          <circle
+            key={`${cx}-${cy}`}
+            cx={cx}
+            cy={cy}
+            r="10"
+            className={cn(
+              "transition-colors",
+              held ? "fill-primary" : "fill-foreground",
+            )}
+          />
+        ))}
+      </svg>
+    </button>
+  );
+}

--- a/components/kniffel/kniffel-game.tsx
+++ b/components/kniffel/kniffel-game.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { RotateCcw, Trophy } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { getGrandTotal, getWinners } from "@/lib/kniffel";
+import { KniffelDice } from "./kniffel-dice";
+import { KniffelModeSelect } from "./kniffel-mode-select";
+import { KniffelPlayerSetup } from "./kniffel-player-setup";
+import { KniffelScoreInput } from "./kniffel-score-input";
+import { KniffelScorecard } from "./kniffel-scorecard";
+import { useKniffel } from "./use-kniffel";
+
+interface KniffelGameProps {
+  locale: string;
+}
+
+export function KniffelGame({ locale }: KniffelGameProps) {
+  const {
+    gameState,
+    rolling,
+    manualScoreInput,
+    canRoll,
+    selectMode,
+    startGame,
+    roll,
+    toggleDieHold,
+    selectCategory,
+    openManualScore,
+    submitManualScore,
+    cancelManualScore,
+    resetGame,
+  } = useKniffel();
+
+  // Mode selection
+  if (gameState.phase === "mode-select") {
+    return <KniffelModeSelect onSelectMode={selectMode} locale={locale} />;
+  }
+
+  // Player setup
+  if (gameState.phase === "setup") {
+    return <KniffelPlayerSetup onStart={startGame} locale={locale} />;
+  }
+
+  // Game finished
+  if (gameState.phase === "finished") {
+    const winners = getWinners(gameState.players);
+    const winnerNames = winners.map((w) => w.name).join(", ");
+    const winnerScore = winners[0] ? getGrandTotal(winners[0]) : 0;
+
+    return (
+      <div className="flex flex-col items-center gap-6 w-full">
+        <div className="flex flex-col items-center gap-2 p-6 rounded-xl bg-primary/10 border border-primary/20">
+          <Trophy className="size-12 text-primary" />
+          <h2 className="text-2xl font-bold">
+            {locale === "de" ? "Spiel beendet!" : "Game Over!"}
+          </h2>
+          <p className="text-lg">
+            {winners.length > 1 ? (
+              locale === "de" ? (
+                <>Unentschieden: {winnerNames}</>
+              ) : (
+                <>Tie: {winnerNames}</>
+              )
+            ) : (
+              <>
+                {locale === "de" ? "Gewinner:" : "Winner:"} {winnerNames}
+              </>
+            )}
+          </p>
+          <p className="text-muted-foreground">
+            {locale === "de" ? "Punktzahl:" : "Score:"} {winnerScore}
+          </p>
+        </div>
+
+        {gameState.mode && (
+          <KniffelScorecard
+            players={gameState.players}
+            currentPlayerIndex={-1}
+            dice={gameState.dice}
+            hasRolled={false}
+            mode={gameState.mode}
+            onSelectCategory={() => {}}
+            locale={locale}
+          />
+        )}
+
+        <Button onClick={resetGame} variant="outline" className="gap-2">
+          <RotateCcw className="size-4" />
+          {locale === "de" ? "Neues Spiel" : "New Game"}
+        </Button>
+      </div>
+    );
+  }
+
+  // Playing
+  const currentPlayer = gameState.players[gameState.currentPlayerIndex];
+  const turnLabel =
+    locale === "de"
+      ? `Runde ${gameState.currentTurn}/13`
+      : `Turn ${gameState.currentTurn}/13`;
+
+  return (
+    <div className="flex flex-col items-center gap-6 w-full">
+      {/* Current player indicator */}
+      <div className="flex flex-col items-center gap-1">
+        <span className="text-sm text-muted-foreground">{turnLabel}</span>
+        <h2 className="text-xl font-semibold">
+          {gameState.mode === "digital" ? (
+            <>
+              {currentPlayer?.name}
+              {locale === "de" ? " ist dran" : "'s turn"}
+            </>
+          ) : locale === "de" ? (
+            "Punkte eintragen"
+          ) : (
+            "Enter scores"
+          )}
+        </h2>
+      </div>
+
+      {/* Dice (digital mode only) */}
+      {gameState.mode === "digital" && (
+        <KniffelDice
+          dice={gameState.dice}
+          rollsRemaining={gameState.rollsRemaining}
+          hasRolled={gameState.hasRolled}
+          canRoll={canRoll}
+          onRoll={roll}
+          onToggleHold={toggleDieHold}
+          locale={locale}
+          rolling={rolling}
+        />
+      )}
+
+      {/* Scorecard */}
+      {gameState.mode && (
+        <KniffelScorecard
+          players={gameState.players}
+          currentPlayerIndex={gameState.currentPlayerIndex}
+          dice={gameState.dice}
+          hasRolled={gameState.hasRolled}
+          mode={gameState.mode}
+          onSelectCategory={selectCategory}
+          onManualScore={
+            gameState.mode === "tracker" ? openManualScore : undefined
+          }
+          locale={locale}
+        />
+      )}
+
+      {/* Reset button */}
+      <Button onClick={resetGame} variant="ghost" size="sm" className="gap-2">
+        <RotateCcw className="size-4" />
+        {locale === "de" ? "Neues Spiel" : "New Game"}
+      </Button>
+
+      {/* Manual score input modal */}
+      {manualScoreInput && (
+        <KniffelScoreInput
+          onSubmit={submitManualScore}
+          onCancel={cancelManualScore}
+          locale={locale}
+          initialValue={manualScoreInput.currentScore}
+        />
+      )}
+    </div>
+  );
+}

--- a/components/kniffel/kniffel-mode-select.tsx
+++ b/components/kniffel/kniffel-mode-select.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { Dices, Pencil } from "lucide-react";
+import type { GameMode } from "@/lib/kniffel";
+
+interface KniffelModeSelectProps {
+  onSelectMode: (mode: GameMode) => void;
+  locale: string;
+}
+
+export function KniffelModeSelect({
+  onSelectMode,
+  locale,
+}: KniffelModeSelectProps) {
+  const digitalTitle = locale === "de" ? "Digital" : "Digital";
+  const digitalDesc =
+    locale === "de"
+      ? "Virtuelle Würfel und automatische Punktzählung"
+      : "Virtual dice with automatic scoring";
+
+  const trackerTitle = locale === "de" ? "Tracker" : "Tracker";
+  const trackerDesc =
+    locale === "de"
+      ? "Manuelle Eingabe für echte Würfelspiele"
+      : "Manual entry for physical dice games";
+
+  return (
+    <div className="flex flex-col items-center gap-6">
+      <h2 className="text-xl font-semibold">
+        {locale === "de" ? "Spielmodus wählen" : "Select Game Mode"}
+      </h2>
+
+      <div className="grid gap-4 sm:grid-cols-2 w-full max-w-md">
+        <button
+          type="button"
+          onClick={() => onSelectMode("digital")}
+          className="flex flex-col items-center gap-3 rounded-xl border-2 border-border bg-card p-6 transition-all hover:border-primary hover:bg-primary/5"
+        >
+          <Dices className="size-12 text-primary" />
+          <div className="text-center">
+            <h3 className="font-semibold">{digitalTitle}</h3>
+            <p className="text-sm text-muted-foreground">{digitalDesc}</p>
+          </div>
+        </button>
+
+        <button
+          type="button"
+          onClick={() => onSelectMode("tracker")}
+          className="flex flex-col items-center gap-3 rounded-xl border-2 border-border bg-card p-6 transition-all hover:border-primary hover:bg-primary/5"
+        >
+          <Pencil className="size-12 text-primary" />
+          <div className="text-center">
+            <h3 className="font-semibold">{trackerTitle}</h3>
+            <p className="text-sm text-muted-foreground">{trackerDesc}</p>
+          </div>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/kniffel/kniffel-player-setup.tsx
+++ b/components/kniffel/kniffel-player-setup.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { Minus, Plus } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+
+interface KniffelPlayerSetupProps {
+  onStart: (playerNames: string[]) => void;
+  locale: string;
+}
+
+const MAX_PLAYERS = 12;
+const MIN_PLAYERS = 1;
+
+export function KniffelPlayerSetup({
+  onStart,
+  locale,
+}: KniffelPlayerSetupProps) {
+  const [playerNames, setPlayerNames] = useState<string[]>([
+    locale === "de" ? "Spieler 1" : "Player 1",
+  ]);
+
+  const addPlayer = () => {
+    if (playerNames.length < MAX_PLAYERS) {
+      const num = playerNames.length + 1;
+      setPlayerNames([
+        ...playerNames,
+        locale === "de" ? `Spieler ${num}` : `Player ${num}`,
+      ]);
+    }
+  };
+
+  const removePlayer = () => {
+    if (playerNames.length > MIN_PLAYERS) {
+      setPlayerNames(playerNames.slice(0, -1));
+    }
+  };
+
+  const updateName = (index: number, name: string) => {
+    const newNames = [...playerNames];
+    newNames[index] = name;
+    setPlayerNames(newNames);
+  };
+
+  const handleStart = () => {
+    const validNames = playerNames.map(
+      (name, i) =>
+        name.trim() ||
+        (locale === "de" ? `Spieler ${i + 1}` : `Player ${i + 1}`),
+    );
+    onStart(validNames);
+  };
+
+  const playersLabel = locale === "de" ? "Spieler" : "Players";
+  const startLabel = locale === "de" ? "Spiel starten" : "Start Game";
+
+  return (
+    <div className="flex flex-col items-center gap-6 w-full max-w-md">
+      <h2 className="text-xl font-semibold">
+        {locale === "de" ? "Spieler eingeben" : "Enter Players"}
+      </h2>
+
+      <div className="flex items-center gap-4">
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={removePlayer}
+          disabled={playerNames.length <= MIN_PLAYERS}
+        >
+          <Minus className="size-4" />
+        </Button>
+        <span className="text-lg font-medium min-w-[8rem] text-center">
+          {playerNames.length} {playersLabel}
+        </span>
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={addPlayer}
+          disabled={playerNames.length >= MAX_PLAYERS}
+        >
+          <Plus className="size-4" />
+        </Button>
+      </div>
+
+      <div className="flex flex-col gap-3 w-full">
+        {playerNames.map((name, index) => (
+          <input
+            // biome-ignore lint/suspicious/noArrayIndexKey: list only adds/removes at end
+            key={index}
+            type="text"
+            value={name}
+            onChange={(e) => updateName(index, e.target.value)}
+            placeholder={
+              locale === "de" ? `Spieler ${index + 1}` : `Player ${index + 1}`
+            }
+            className="w-full rounded-lg border border-border bg-background px-4 py-2 text-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+          />
+        ))}
+      </div>
+
+      <Button onClick={handleStart} size="lg" className="w-full">
+        {startLabel}
+      </Button>
+    </div>
+  );
+}

--- a/components/kniffel/kniffel-score-input.tsx
+++ b/components/kniffel/kniffel-score-input.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+
+interface KniffelScoreInputProps {
+  onSubmit: (score: number) => void;
+  onCancel: () => void;
+  locale: string;
+  initialValue?: number | null;
+}
+
+export function KniffelScoreInput({
+  onSubmit,
+  onCancel,
+  locale,
+  initialValue,
+}: KniffelScoreInputProps) {
+  const [value, setValue] = useState(
+    initialValue !== null && initialValue !== undefined
+      ? String(initialValue)
+      : "",
+  );
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, []);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const score = Number.parseInt(value, 10);
+    if (!Number.isNaN(score) && score >= 0) {
+      onSubmit(score);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm">
+      <div className="rounded-xl border border-border bg-card p-6 shadow-lg w-full max-w-xs">
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <h3 className="text-lg font-semibold text-center">
+            {locale === "de" ? "Punktzahl eingeben" : "Enter Score"}
+          </h3>
+
+          <input
+            ref={inputRef}
+            type="number"
+            min="0"
+            max="50"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            placeholder="0"
+            className="w-full rounded-lg border border-border bg-background px-4 py-3 text-center text-2xl font-bold focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
+          />
+
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onCancel}
+              className="flex-1"
+            >
+              {locale === "de" ? "Abbrechen" : "Cancel"}
+            </Button>
+            <Button type="submit" className="flex-1">
+              {locale === "de" ? "OK" : "OK"}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/components/kniffel/kniffel-scorecard.tsx
+++ b/components/kniffel/kniffel-scorecard.tsx
@@ -1,0 +1,303 @@
+"use client";
+
+import {
+  calculateScore,
+  type DieState,
+  type GameMode,
+  getGrandTotal,
+  getLowerTotal,
+  getUpperBonus,
+  getUpperTotal,
+  LOWER_CATEGORIES,
+  type Player,
+  type ScoreCategory,
+  UPPER_CATEGORIES,
+} from "@/lib/kniffel";
+import { cn } from "@/lib/utils";
+
+interface KniffelScorecardProps {
+  players: Player[];
+  currentPlayerIndex: number;
+  dice: DieState[];
+  hasRolled: boolean;
+  mode: GameMode;
+  onSelectCategory: (category: ScoreCategory) => void;
+  onManualScore?: (playerId: string, category: ScoreCategory) => void;
+  locale: string;
+}
+
+const categoryLabels: Record<ScoreCategory, { en: string; de: string }> = {
+  ones: { en: "Ones", de: "Einser" },
+  twos: { en: "Twos", de: "Zweier" },
+  threes: { en: "Threes", de: "Dreier" },
+  fours: { en: "Fours", de: "Vierer" },
+  fives: { en: "Fives", de: "Fünfer" },
+  sixes: { en: "Sixes", de: "Sechser" },
+  threeOfAKind: { en: "Three of a Kind", de: "Dreierpasch" },
+  fourOfAKind: { en: "Four of a Kind", de: "Viererpasch" },
+  fullHouse: { en: "Full House", de: "Full House" },
+  smallStraight: { en: "Small Straight", de: "Kleine Straße" },
+  largeStraight: { en: "Large Straight", de: "Große Straße" },
+  kniffel: { en: "Kniffel", de: "Kniffel" },
+  chance: { en: "Chance", de: "Chance" },
+};
+
+interface ScoreCellProps {
+  player: Player;
+  category: ScoreCategory;
+  isCurrentPlayer: boolean;
+  potentialScore: number | null;
+  mode: GameMode;
+  hasRolled: boolean;
+  onSelect: () => void;
+  onManualScore?: () => void;
+}
+
+function ScoreCell({
+  player,
+  category,
+  isCurrentPlayer,
+  potentialScore,
+  mode,
+  hasRolled,
+  onSelect,
+  onManualScore,
+}: ScoreCellProps) {
+  const score = player.scores[category];
+  const isFilled = score !== null;
+  const canSelect =
+    mode === "digital" && isCurrentPlayer && hasRolled && !isFilled;
+  // In tracker mode, allow editing both filled and unfilled cells
+  const canManualEdit = mode === "tracker";
+
+  const handleClick = () => {
+    if (canSelect) {
+      onSelect();
+    } else if (canManualEdit && onManualScore) {
+      onManualScore();
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      handleClick();
+    }
+  };
+
+  const isInteractive = canSelect || canManualEdit;
+
+  // Only show current player highlight in digital mode
+  const showCurrentHighlight =
+    mode === "digital" && isCurrentPlayer && !isFilled;
+
+  return (
+    <td
+      className={cn(
+        "border border-border px-2 py-1 text-center min-w-[3rem]",
+        canSelect && "cursor-pointer hover:bg-primary/10 bg-primary/5",
+        canManualEdit && !isFilled && "cursor-pointer hover:bg-muted/50",
+        canManualEdit && isFilled && "cursor-pointer hover:bg-muted/30",
+        showCurrentHighlight && "bg-accent/30",
+        isInteractive &&
+          "focus:outline-none focus:ring-2 focus:ring-primary/50",
+      )}
+      onClick={handleClick}
+      onKeyDown={isInteractive ? handleKeyDown : undefined}
+      tabIndex={isInteractive ? 0 : undefined}
+      role={isInteractive ? "button" : undefined}
+    >
+      {isFilled ? (
+        <span className="font-medium">{score}</span>
+      ) : canSelect && potentialScore !== null ? (
+        <span className="text-muted-foreground">{potentialScore}</span>
+      ) : (
+        <span className="text-muted-foreground/50">-</span>
+      )}
+    </td>
+  );
+}
+
+export function KniffelScorecard({
+  players,
+  currentPlayerIndex,
+  dice,
+  hasRolled,
+  mode,
+  onSelectCategory,
+  onManualScore,
+  locale,
+}: KniffelScorecardProps) {
+  const t = (key: ScoreCategory) =>
+    locale === "de" ? categoryLabels[key].de : categoryLabels[key].en;
+
+  const upperSubtotalLabel = locale === "de" ? "Zwischensumme" : "Subtotal";
+  const bonusLabel = locale === "de" ? "Bonus (≥63)" : "Bonus (≥63)";
+  const upperTotalLabel = locale === "de" ? "Oberer Teil" : "Upper Total";
+  const lowerTotalLabel = locale === "de" ? "Unterer Teil" : "Lower Total";
+  const grandTotalLabel = locale === "de" ? "Gesamtsumme" : "Grand Total";
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="border-collapse text-sm">
+        <thead>
+          <tr className="bg-muted/50">
+            <th className="border border-border px-3 py-2 text-left font-semibold min-w-[8rem]">
+              {locale === "de" ? "Kategorie" : "Category"}
+            </th>
+            {players.map((player, idx) => (
+              <th
+                key={player.id}
+                className={cn(
+                  "border border-border px-3 py-2 text-center font-semibold min-w-[4rem]",
+                  idx === currentPlayerIndex &&
+                    mode === "digital" &&
+                    "bg-primary/20",
+                )}
+              >
+                {player.name}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {/* Upper Section */}
+          {UPPER_CATEGORIES.map((category) => (
+            <tr key={category}>
+              <td className="border border-border px-3 py-1 font-medium">
+                {t(category)}
+              </td>
+              {players.map((player, idx) => (
+                <ScoreCell
+                  key={player.id}
+                  player={player}
+                  category={category}
+                  isCurrentPlayer={idx === currentPlayerIndex}
+                  potentialScore={
+                    hasRolled && idx === currentPlayerIndex
+                      ? calculateScore(category, dice)
+                      : null
+                  }
+                  mode={mode}
+                  hasRolled={hasRolled}
+                  onSelect={() => onSelectCategory(category)}
+                  onManualScore={
+                    onManualScore
+                      ? () => onManualScore(player.id, category)
+                      : undefined
+                  }
+                />
+              ))}
+            </tr>
+          ))}
+
+          {/* Upper Section Totals */}
+          <tr className="bg-muted/30">
+            <td className="border border-border px-3 py-1 font-medium">
+              {upperSubtotalLabel}
+            </td>
+            {players.map((player) => (
+              <td
+                key={player.id}
+                className="border border-border px-2 py-1 text-center font-medium"
+              >
+                {getUpperTotal(player)}
+              </td>
+            ))}
+          </tr>
+          <tr className="bg-muted/30">
+            <td className="border border-border px-3 py-1 font-medium">
+              {bonusLabel}
+            </td>
+            {players.map((player) => (
+              <td
+                key={player.id}
+                className="border border-border px-2 py-1 text-center font-medium"
+              >
+                {getUpperBonus(player)}
+              </td>
+            ))}
+          </tr>
+          <tr className="bg-muted/50">
+            <td className="border border-border px-3 py-1 font-semibold">
+              {upperTotalLabel}
+            </td>
+            {players.map((player) => (
+              <td
+                key={player.id}
+                className="border border-border px-2 py-1 text-center font-semibold"
+              >
+                {getUpperTotal(player) + getUpperBonus(player)}
+              </td>
+            ))}
+          </tr>
+
+          {/* Separator */}
+          <tr>
+            <td colSpan={players.length + 1} className="h-2" />
+          </tr>
+
+          {/* Lower Section */}
+          {LOWER_CATEGORIES.map((category) => (
+            <tr key={category}>
+              <td className="border border-border px-3 py-1 font-medium">
+                {t(category)}
+              </td>
+              {players.map((player, idx) => (
+                <ScoreCell
+                  key={player.id}
+                  player={player}
+                  category={category}
+                  isCurrentPlayer={idx === currentPlayerIndex}
+                  potentialScore={
+                    hasRolled && idx === currentPlayerIndex
+                      ? calculateScore(category, dice)
+                      : null
+                  }
+                  mode={mode}
+                  hasRolled={hasRolled}
+                  onSelect={() => onSelectCategory(category)}
+                  onManualScore={
+                    onManualScore
+                      ? () => onManualScore(player.id, category)
+                      : undefined
+                  }
+                />
+              ))}
+            </tr>
+          ))}
+
+          {/* Lower Section Total */}
+          <tr className="bg-muted/50">
+            <td className="border border-border px-3 py-1 font-semibold">
+              {lowerTotalLabel}
+            </td>
+            {players.map((player) => (
+              <td
+                key={player.id}
+                className="border border-border px-2 py-1 text-center font-semibold"
+              >
+                {getLowerTotal(player)}
+              </td>
+            ))}
+          </tr>
+
+          {/* Grand Total */}
+          <tr className="bg-primary/10">
+            <td className="border border-border px-3 py-2 font-bold">
+              {grandTotalLabel}
+            </td>
+            {players.map((player) => (
+              <td
+                key={player.id}
+                className="border border-border px-2 py-2 text-center font-bold text-lg"
+              >
+                {getGrandTotal(player)}
+              </td>
+            ))}
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/components/kniffel/use-kniffel.ts
+++ b/components/kniffel/use-kniffel.ts
@@ -1,0 +1,313 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  ALL_CATEGORIES,
+  calculateScore,
+  createInitialDice,
+  type GameMode,
+  type GameState,
+  isPlayerComplete,
+  MAX_ROLLS,
+  type Player,
+  resetHolds,
+  rollDice,
+  type ScoreCategory,
+  type StoredGameState,
+  toggleHold,
+} from "@/lib/kniffel";
+
+const STORAGE_KEY = "kniffel-state";
+
+function createEmptyScores(): Record<ScoreCategory, number | null> {
+  return Object.fromEntries(ALL_CATEGORIES.map((cat) => [cat, null])) as Record<
+    ScoreCategory,
+    number | null
+  >;
+}
+
+function createPlayer(id: string, name: string): Player {
+  return {
+    id,
+    name,
+    scores: createEmptyScores(),
+  };
+}
+
+function createInitialState(): GameState {
+  return {
+    mode: null,
+    phase: "mode-select",
+    players: [],
+    currentPlayerIndex: 0,
+    currentTurn: 1,
+    dice: createInitialDice(),
+    rollsRemaining: MAX_ROLLS,
+    hasRolled: false,
+  };
+}
+
+function loadGameState(): StoredGameState | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) return null;
+    return JSON.parse(stored) as StoredGameState;
+  } catch {
+    return null;
+  }
+}
+
+function saveGameState(state: GameState): void {
+  if (typeof window === "undefined") return;
+  if (state.phase === "mode-select" || !state.mode) {
+    clearGameState();
+    return;
+  }
+  try {
+    const toStore: StoredGameState = {
+      mode: state.mode,
+      phase: state.phase,
+      players: state.players,
+      currentPlayerIndex: state.currentPlayerIndex,
+      currentTurn: state.currentTurn,
+      dice: state.dice,
+      rollsRemaining: state.rollsRemaining,
+      hasRolled: state.hasRolled,
+      timestamp: Date.now(),
+    };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(toStore));
+  } catch {
+    // Ignore storage errors
+  }
+}
+
+function clearGameState(): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // Ignore storage errors
+  }
+}
+
+export function useKniffel() {
+  const [gameState, setGameState] = useState<GameState>(() => {
+    const stored = loadGameState();
+    if (stored && stored.phase !== "mode-select") {
+      return {
+        mode: stored.mode,
+        phase: stored.phase,
+        players: stored.players,
+        currentPlayerIndex: stored.currentPlayerIndex,
+        currentTurn: stored.currentTurn,
+        dice: stored.dice,
+        rollsRemaining: stored.rollsRemaining,
+        hasRolled: stored.hasRolled,
+      };
+    }
+    return createInitialState();
+  });
+
+  const [rolling, setRolling] = useState(false);
+  const [manualScoreInput, setManualScoreInput] = useState<{
+    playerId: string;
+    category: ScoreCategory;
+    currentScore: number | null;
+  } | null>(null);
+
+  // Save state on changes
+  useEffect(() => {
+    saveGameState(gameState);
+  }, [gameState]);
+
+  const selectMode = useCallback((mode: GameMode) => {
+    setGameState((prev) => ({
+      ...prev,
+      mode,
+      phase: "setup",
+    }));
+  }, []);
+
+  const startGame = useCallback((playerNames: string[]) => {
+    const players = playerNames.map((name, i) =>
+      createPlayer(`player-${i}`, name),
+    );
+    setGameState((prev) => ({
+      ...prev,
+      phase: "playing",
+      players,
+      currentPlayerIndex: 0,
+      currentTurn: 1,
+      dice: createInitialDice(),
+      rollsRemaining: MAX_ROLLS,
+      hasRolled: false,
+    }));
+  }, []);
+
+  const roll = useCallback(() => {
+    if (gameState.rollsRemaining <= 0 || gameState.phase !== "playing") return;
+    if (gameState.mode !== "digital") return;
+
+    setRolling(true);
+    setTimeout(() => {
+      setGameState((prev) => ({
+        ...prev,
+        dice: rollDice(prev.dice),
+        rollsRemaining: prev.rollsRemaining - 1,
+        hasRolled: true,
+      }));
+      setRolling(false);
+    }, 300);
+  }, [gameState.rollsRemaining, gameState.phase, gameState.mode]);
+
+  const toggleDieHold = useCallback(
+    (index: number) => {
+      if (!gameState.hasRolled || gameState.phase !== "playing") return;
+      if (gameState.mode !== "digital") return;
+
+      setGameState((prev) => ({
+        ...prev,
+        dice: toggleHold(prev.dice, index),
+      }));
+    },
+    [gameState.hasRolled, gameState.phase, gameState.mode],
+  );
+
+  const selectCategory = useCallback(
+    (category: ScoreCategory) => {
+      if (!gameState.hasRolled || gameState.phase !== "playing") return;
+      if (gameState.mode !== "digital") return;
+
+      const currentPlayer = gameState.players[gameState.currentPlayerIndex];
+      if (!currentPlayer || currentPlayer.scores[category] !== null) return;
+
+      const score = calculateScore(category, gameState.dice);
+
+      setGameState((prev) => {
+        const playerToUpdate = prev.players[prev.currentPlayerIndex];
+        if (!playerToUpdate) return prev;
+
+        const newPlayers = [...prev.players];
+        newPlayers[prev.currentPlayerIndex] = {
+          ...playerToUpdate,
+          scores: {
+            ...playerToUpdate.scores,
+            [category]: score,
+          },
+        };
+
+        // Check if game is finished
+        const allComplete = newPlayers.every(isPlayerComplete);
+        if (allComplete) {
+          return {
+            ...prev,
+            players: newPlayers,
+            phase: "finished",
+          };
+        }
+
+        // Move to next player or next turn
+        const nextPlayerIndex =
+          (prev.currentPlayerIndex + 1) % prev.players.length;
+        const nextTurn =
+          nextPlayerIndex === 0 ? prev.currentTurn + 1 : prev.currentTurn;
+
+        return {
+          ...prev,
+          players: newPlayers,
+          currentPlayerIndex: nextPlayerIndex,
+          currentTurn: nextTurn,
+          dice: resetHolds(createInitialDice()),
+          rollsRemaining: MAX_ROLLS,
+          hasRolled: false,
+        };
+      });
+    },
+    [
+      gameState.hasRolled,
+      gameState.phase,
+      gameState.mode,
+      gameState.players,
+      gameState.currentPlayerIndex,
+      gameState.dice,
+    ],
+  );
+
+  const openManualScore = useCallback(
+    (playerId: string, category: ScoreCategory) => {
+      if (gameState.mode !== "tracker") return;
+      const player = gameState.players.find((p) => p.id === playerId);
+      const currentScore = player?.scores[category] ?? null;
+      setManualScoreInput({ playerId, category, currentScore });
+    },
+    [gameState.mode, gameState.players],
+  );
+
+  const submitManualScore = useCallback(
+    (score: number) => {
+      if (!manualScoreInput) return;
+
+      setGameState((prev) => {
+        const playerIndex = prev.players.findIndex(
+          (p) => p.id === manualScoreInput.playerId,
+        );
+        if (playerIndex === -1) return prev;
+
+        const playerToUpdate = prev.players[playerIndex];
+        if (!playerToUpdate) return prev;
+
+        const newPlayers = [...prev.players];
+        newPlayers[playerIndex] = {
+          ...playerToUpdate,
+          scores: {
+            ...playerToUpdate.scores,
+            [manualScoreInput.category]: score,
+          },
+        };
+
+        const allComplete = newPlayers.every(isPlayerComplete);
+
+        return {
+          ...prev,
+          players: newPlayers,
+          phase: allComplete ? "finished" : prev.phase,
+        };
+      });
+
+      setManualScoreInput(null);
+    },
+    [manualScoreInput],
+  );
+
+  const cancelManualScore = useCallback(() => {
+    setManualScoreInput(null);
+  }, []);
+
+  const resetGame = useCallback(() => {
+    clearGameState();
+    setGameState(createInitialState());
+    setManualScoreInput(null);
+  }, []);
+
+  const canRoll =
+    gameState.mode === "digital" &&
+    gameState.phase === "playing" &&
+    gameState.rollsRemaining > 0;
+
+  return {
+    gameState,
+    rolling,
+    manualScoreInput,
+    canRoll,
+    selectMode,
+    startGame,
+    roll,
+    toggleDieHold,
+    selectCategory,
+    openManualScore,
+    submitManualScore,
+    cancelManualScore,
+    resetGame,
+  };
+}

--- a/components/wordle/wordle-game.tsx
+++ b/components/wordle/wordle-game.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { Bot, RotateCcw } from "lucide-react";
+import { Bot, Keyboard, RotateCcw } from "lucide-react";
 import Link from "next/link";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { WORDS_DE, WORDS_EN } from "@/lib/wordle";
 import { SolverHintButton, useSolver } from "./solver";
@@ -15,6 +15,7 @@ interface WordleGameProps {
 }
 
 export function WordleGame({ locale }: WordleGameProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
   const {
     gameState,
     boardRows,
@@ -29,6 +30,16 @@ export function WordleGame({ locale }: WordleGameProps) {
   } = useWordle(locale);
 
   const [hintEnabled, setHintEnabled] = useState(false);
+  const [showKeyboard, setShowKeyboard] = useState(() => {
+    if (typeof window === "undefined") return true;
+    const stored = localStorage.getItem("wordle-show-keyboard");
+    return stored !== "false";
+  });
+
+  useEffect(() => {
+    localStorage.setItem("wordle-show-keyboard", String(showKeyboard));
+  }, [showKeyboard]);
+
   const wordList = locale === "de" ? WORDS_DE : WORDS_EN;
   const { suggestions, possibleWordsCount } = useSolver({
     wordList,
@@ -36,6 +47,34 @@ export function WordleGame({ locale }: WordleGameProps) {
     solution: gameState.solution,
     enabled: hintEnabled && gameState.gameStatus === "playing",
   });
+
+  const handleMobileInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    if (value.length > 0) {
+      const lastChar = value.at(-1);
+      if (lastChar && /^[a-zA-ZäöüÄÖÜ]$/.test(lastChar)) {
+        addLetter(lastChar);
+      }
+    }
+    // Always clear the input
+    e.target.value = "";
+  };
+
+  const handleMobileKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      submitGuess();
+    } else if (e.key === "Backspace") {
+      e.preventDefault();
+      removeLetter();
+    }
+  };
+
+  const focusInput = () => {
+    if (gameState.gameStatus === "playing") {
+      inputRef.current?.focus();
+    }
+  };
 
   return (
     <div className="flex flex-col items-center gap-6 w-full">
@@ -58,13 +97,35 @@ export function WordleGame({ locale }: WordleGameProps) {
         )}
       </div>
 
-      {/* Game board */}
-      <WordleBoard
-        rows={boardRows}
-        shakeRow={shakeRow}
-        currentRowIndex={currentRowIndex}
-        currentTileIndex={currentTileIndex}
+      {/* Hidden input for mobile keyboard */}
+      <input
+        ref={inputRef}
+        type="text"
+        inputMode="text"
+        autoComplete="off"
+        autoCorrect="off"
+        autoCapitalize="off"
+        spellCheck={false}
+        className="sr-only"
+        onChange={handleMobileInput}
+        onKeyDown={handleMobileKeyDown}
+        aria-label="Type your guess"
       />
+
+      {/* Game board */}
+      <button
+        type="button"
+        onClick={focusInput}
+        className="focus:outline-none"
+        aria-label="Tap to type"
+      >
+        <WordleBoard
+          rows={boardRows}
+          shakeRow={shakeRow}
+          currentRowIndex={currentRowIndex}
+          currentTileIndex={currentTileIndex}
+        />
+      </button>
 
       {/* Controls */}
       <div className="flex flex-wrap items-center justify-center gap-2">
@@ -99,16 +160,29 @@ export function WordleGame({ locale }: WordleGameProps) {
             {locale === "de" ? "Solver" : "Solver"}
           </Link>
         </Button>
+
+        <Button
+          variant={showKeyboard ? "secondary" : "ghost"}
+          size="sm"
+          onClick={() => setShowKeyboard(!showKeyboard)}
+          className="gap-2"
+          aria-label={showKeyboard ? "Hide keyboard" : "Show keyboard"}
+        >
+          <Keyboard className="size-4" />
+        </Button>
       </div>
 
       {/* Keyboard */}
-      <WordleKeyboard
-        letterStates={gameState.letterStates}
-        onKey={addLetter}
-        onEnter={submitGuess}
-        onBackspace={removeLetter}
-        locale={locale}
-      />
+      {showKeyboard && (
+        <WordleKeyboard
+          letterStates={gameState.letterStates}
+          onKey={addLetter}
+          onEnter={submitGuess}
+          onBackspace={removeLetter}
+          locale={locale}
+          disabled={gameState.gameStatus !== "playing"}
+        />
+      )}
     </div>
   );
 }

--- a/components/wordle/wordle-keyboard.tsx
+++ b/components/wordle/wordle-keyboard.tsx
@@ -18,8 +18,10 @@ const keyVariants = cva(
         absent: "bg-muted/50 text-muted-foreground hover:bg-muted/40",
       },
       size: {
-        default: "h-14 min-w-[32px] px-2 sm:min-w-[43px] sm:px-3 text-sm",
-        wide: "h-14 min-w-[50px] px-2 sm:min-w-[65px] sm:px-4 text-xs",
+        default: "h-14 min-w-[32px] px-1.5 sm:min-w-[43px] sm:px-3 text-sm",
+        compact:
+          "h-14 min-w-[26px] px-1 sm:min-w-[38px] sm:px-2 text-xs sm:text-sm",
+        wide: "h-14 min-w-[44px] px-1.5 sm:min-w-[65px] sm:px-4 text-xs",
       },
     },
     defaultVariants: {
@@ -49,6 +51,7 @@ interface WordleKeyboardProps {
   onEnter: () => void;
   onBackspace: () => void;
   locale: string;
+  disabled?: boolean;
 }
 
 export function WordleKeyboard({
@@ -57,10 +60,13 @@ export function WordleKeyboard({
   onEnter,
   onBackspace,
   locale,
+  disabled = false,
 }: WordleKeyboardProps) {
   const keyboard = locale === "de" ? KEYBOARD_DE : KEYBOARD_EN;
+  const isGerman = locale === "de";
 
   const handleClick = (key: string) => {
+    if (disabled) return;
     if (key === "ENTER") {
       onEnter();
     } else if (key === "BACKSPACE") {
@@ -82,12 +88,17 @@ export function WordleKeyboard({
     return "unused";
   };
 
+  const getKeySize = (key: string) => {
+    if (key === "ENTER" || key === "BACKSPACE") return "wide";
+    if (isGerman) return "compact";
+    return "default";
+  };
+
   return (
     <div className="flex flex-col gap-1.5 w-full max-w-lg">
       {keyboard.map((row) => (
         <div key={row.join("")} className="flex justify-center gap-1">
           {row.map((key) => {
-            const isWide = key === "ENTER" || key === "BACKSPACE";
             const state = getKeyState(key);
 
             return (
@@ -95,11 +106,13 @@ export function WordleKeyboard({
                 key={key}
                 type="button"
                 onClick={() => handleClick(key)}
+                disabled={disabled}
                 className={cn(
                   keyVariants({
                     state,
-                    size: isWide ? "wide" : "default",
+                    size: getKeySize(key),
                   }),
+                  disabled && "opacity-50 cursor-not-allowed",
                 )}
                 aria-label={
                   key === "BACKSPACE"

--- a/lib/kniffel/__tests__/scoring.test.ts
+++ b/lib/kniffel/__tests__/scoring.test.ts
@@ -1,0 +1,441 @@
+import { describe, expect, it } from "vitest";
+import {
+  calculateScore,
+  countDice,
+  getDiceValues,
+  getGrandTotal,
+  getLowerTotal,
+  getUpperBonus,
+  getUpperTotal,
+  getWinners,
+  hasNOfAKind,
+  isFullHouse,
+  isKniffel,
+  isLargeStraight,
+  isPlayerComplete,
+  isSmallStraight,
+  scoreChance,
+  scoreFourOfAKind,
+  scoreFullHouse,
+  scoreKniffel,
+  scoreLargeStraight,
+  scoreSmallStraight,
+  scoreThreeOfAKind,
+  scoreUpper,
+  sumDice,
+} from "../scoring";
+import type { DieState, Player, ScoreCategory } from "../types";
+
+function createDice(values: number[]): DieState[] {
+  return values.map((value) => ({ value, held: false }));
+}
+
+function createPlayer(
+  scores: Partial<Record<ScoreCategory, number | null>>,
+): Player {
+  const defaultScores: Record<ScoreCategory, number | null> = {
+    ones: null,
+    twos: null,
+    threes: null,
+    fours: null,
+    fives: null,
+    sixes: null,
+    threeOfAKind: null,
+    fourOfAKind: null,
+    fullHouse: null,
+    smallStraight: null,
+    largeStraight: null,
+    kniffel: null,
+    chance: null,
+  };
+  return {
+    id: "test",
+    name: "Test Player",
+    scores: { ...defaultScores, ...scores },
+  };
+}
+
+describe("getDiceValues", () => {
+  it("extracts values from dice", () => {
+    const dice = createDice([1, 2, 3, 4, 5]);
+    expect(getDiceValues(dice)).toEqual([1, 2, 3, 4, 5]);
+  });
+});
+
+describe("countDice", () => {
+  it("counts occurrences of each value", () => {
+    expect(countDice([1, 1, 2, 3, 3])).toEqual({ 1: 2, 2: 1, 3: 2 });
+  });
+
+  it("handles all same values", () => {
+    expect(countDice([5, 5, 5, 5, 5])).toEqual({ 5: 5 });
+  });
+});
+
+describe("sumDice", () => {
+  it("sums all values", () => {
+    expect(sumDice([1, 2, 3, 4, 5])).toBe(15);
+  });
+});
+
+describe("scoreUpper", () => {
+  it("scores ones correctly", () => {
+    expect(scoreUpper([1, 1, 2, 3, 4], 1)).toBe(2);
+  });
+
+  it("scores sixes correctly", () => {
+    expect(scoreUpper([6, 6, 6, 1, 2], 6)).toBe(18);
+  });
+
+  it("returns 0 when no matches", () => {
+    expect(scoreUpper([2, 3, 4, 5, 6], 1)).toBe(0);
+  });
+});
+
+describe("hasNOfAKind", () => {
+  it("detects three of a kind", () => {
+    expect(hasNOfAKind([3, 3, 3, 1, 2], 3)).toBe(true);
+    expect(hasNOfAKind([3, 3, 1, 1, 2], 3)).toBe(false);
+  });
+
+  it("detects four of a kind", () => {
+    expect(hasNOfAKind([4, 4, 4, 4, 1], 4)).toBe(true);
+    expect(hasNOfAKind([4, 4, 4, 1, 2], 4)).toBe(false);
+  });
+
+  it("detects five of a kind (Kniffel)", () => {
+    expect(hasNOfAKind([5, 5, 5, 5, 5], 5)).toBe(true);
+    expect(hasNOfAKind([5, 5, 5, 5, 1], 5)).toBe(false);
+  });
+});
+
+describe("scoreThreeOfAKind", () => {
+  it("returns sum when valid", () => {
+    expect(scoreThreeOfAKind([3, 3, 3, 1, 2])).toBe(12);
+  });
+
+  it("returns 0 when invalid", () => {
+    expect(scoreThreeOfAKind([3, 3, 1, 1, 2])).toBe(0);
+  });
+});
+
+describe("scoreFourOfAKind", () => {
+  it("returns sum when valid", () => {
+    expect(scoreFourOfAKind([4, 4, 4, 4, 1])).toBe(17);
+  });
+
+  it("returns 0 when invalid", () => {
+    expect(scoreFourOfAKind([4, 4, 4, 1, 2])).toBe(0);
+  });
+});
+
+describe("isFullHouse", () => {
+  it("detects full house", () => {
+    expect(isFullHouse([2, 2, 3, 3, 3])).toBe(true);
+  });
+
+  it("rejects non-full house", () => {
+    expect(isFullHouse([2, 2, 2, 3, 3])).toBe(true); // This is also valid
+    expect(isFullHouse([2, 2, 3, 4, 5])).toBe(false);
+    expect(isFullHouse([1, 1, 1, 1, 1])).toBe(false); // All same is not full house
+  });
+});
+
+describe("scoreFullHouse", () => {
+  it("returns 25 when valid", () => {
+    expect(scoreFullHouse([2, 2, 3, 3, 3])).toBe(25);
+  });
+
+  it("returns 0 when invalid", () => {
+    expect(scoreFullHouse([2, 2, 3, 4, 5])).toBe(0);
+  });
+});
+
+describe("isSmallStraight", () => {
+  it("detects 1-2-3-4 straight", () => {
+    expect(isSmallStraight([1, 2, 3, 4, 6])).toBe(true);
+  });
+
+  it("detects 2-3-4-5 straight", () => {
+    expect(isSmallStraight([2, 3, 4, 5, 1])).toBe(true);
+  });
+
+  it("detects 3-4-5-6 straight", () => {
+    expect(isSmallStraight([3, 4, 5, 6, 1])).toBe(true);
+  });
+
+  it("detects straight with duplicate", () => {
+    expect(isSmallStraight([1, 2, 3, 4, 4])).toBe(true);
+  });
+
+  it("rejects non-straight", () => {
+    expect(isSmallStraight([1, 2, 3, 5, 6])).toBe(false);
+  });
+});
+
+describe("scoreSmallStraight", () => {
+  it("returns 30 when valid", () => {
+    expect(scoreSmallStraight([1, 2, 3, 4, 6])).toBe(30);
+  });
+
+  it("returns 0 when invalid", () => {
+    expect(scoreSmallStraight([1, 2, 3, 5, 6])).toBe(0);
+  });
+});
+
+describe("isLargeStraight", () => {
+  it("detects 1-2-3-4-5 straight", () => {
+    expect(isLargeStraight([1, 2, 3, 4, 5])).toBe(true);
+    expect(isLargeStraight([5, 4, 3, 2, 1])).toBe(true); // unordered
+  });
+
+  it("detects 2-3-4-5-6 straight", () => {
+    expect(isLargeStraight([2, 3, 4, 5, 6])).toBe(true);
+    expect(isLargeStraight([6, 5, 4, 3, 2])).toBe(true); // unordered
+  });
+
+  it("rejects non-large-straight", () => {
+    expect(isLargeStraight([1, 2, 3, 4, 6])).toBe(false);
+  });
+});
+
+describe("scoreLargeStraight", () => {
+  it("returns 40 when valid", () => {
+    expect(scoreLargeStraight([1, 2, 3, 4, 5])).toBe(40);
+  });
+
+  it("returns 0 when invalid", () => {
+    expect(scoreLargeStraight([1, 2, 3, 4, 6])).toBe(0);
+  });
+});
+
+describe("isKniffel", () => {
+  it("detects Kniffel", () => {
+    expect(isKniffel([6, 6, 6, 6, 6])).toBe(true);
+  });
+
+  it("rejects non-Kniffel", () => {
+    expect(isKniffel([6, 6, 6, 6, 5])).toBe(false);
+  });
+});
+
+describe("scoreKniffel", () => {
+  it("returns 50 when valid", () => {
+    expect(scoreKniffel([6, 6, 6, 6, 6])).toBe(50);
+  });
+
+  it("returns 0 when invalid", () => {
+    expect(scoreKniffel([6, 6, 6, 6, 5])).toBe(0);
+  });
+});
+
+describe("scoreChance", () => {
+  it("returns sum of all dice", () => {
+    expect(scoreChance([1, 2, 3, 4, 5])).toBe(15);
+    expect(scoreChance([6, 6, 6, 6, 6])).toBe(30);
+  });
+});
+
+describe("calculateScore", () => {
+  it("calculates upper section scores", () => {
+    const dice = createDice([1, 1, 1, 2, 3]);
+    expect(calculateScore("ones", dice)).toBe(3);
+    expect(calculateScore("twos", dice)).toBe(2);
+    expect(calculateScore("threes", dice)).toBe(3);
+    expect(calculateScore("fours", dice)).toBe(0);
+  });
+
+  it("calculates lower section scores", () => {
+    expect(calculateScore("threeOfAKind", createDice([3, 3, 3, 1, 2]))).toBe(
+      12,
+    );
+    expect(calculateScore("fourOfAKind", createDice([4, 4, 4, 4, 1]))).toBe(17);
+    expect(calculateScore("fullHouse", createDice([2, 2, 3, 3, 3]))).toBe(25);
+    expect(calculateScore("smallStraight", createDice([1, 2, 3, 4, 6]))).toBe(
+      30,
+    );
+    expect(calculateScore("largeStraight", createDice([1, 2, 3, 4, 5]))).toBe(
+      40,
+    );
+    expect(calculateScore("kniffel", createDice([5, 5, 5, 5, 5]))).toBe(50);
+    expect(calculateScore("chance", createDice([1, 2, 3, 4, 5]))).toBe(15);
+  });
+});
+
+describe("getUpperTotal", () => {
+  it("sums upper section scores", () => {
+    const player = createPlayer({
+      ones: 3,
+      twos: 6,
+      threes: 9,
+      fours: 12,
+      fives: 15,
+      sixes: 18,
+    });
+    expect(getUpperTotal(player)).toBe(63);
+  });
+
+  it("treats null as 0", () => {
+    const player = createPlayer({ ones: 3, twos: null });
+    expect(getUpperTotal(player)).toBe(3);
+  });
+});
+
+describe("getUpperBonus", () => {
+  it("returns 35 when total >= 63", () => {
+    const player = createPlayer({
+      ones: 3,
+      twos: 6,
+      threes: 9,
+      fours: 12,
+      fives: 15,
+      sixes: 18,
+    });
+    expect(getUpperBonus(player)).toBe(35);
+  });
+
+  it("returns 0 when total < 63", () => {
+    const player = createPlayer({
+      ones: 3,
+      twos: 6,
+      threes: 9,
+      fours: 12,
+      fives: 15,
+      sixes: 17,
+    });
+    expect(getUpperBonus(player)).toBe(0);
+  });
+});
+
+describe("getLowerTotal", () => {
+  it("sums lower section scores", () => {
+    const player = createPlayer({
+      threeOfAKind: 15,
+      fourOfAKind: 20,
+      fullHouse: 25,
+      smallStraight: 30,
+      largeStraight: 40,
+      kniffel: 50,
+      chance: 20,
+    });
+    expect(getLowerTotal(player)).toBe(200);
+  });
+});
+
+describe("getGrandTotal", () => {
+  it("sums upper + bonus + lower", () => {
+    const player = createPlayer({
+      ones: 3,
+      twos: 6,
+      threes: 9,
+      fours: 12,
+      fives: 15,
+      sixes: 18,
+      threeOfAKind: 15,
+      fourOfAKind: 20,
+      fullHouse: 25,
+      smallStraight: 30,
+      largeStraight: 40,
+      kniffel: 50,
+      chance: 20,
+    });
+    expect(getGrandTotal(player)).toBe(63 + 35 + 200);
+  });
+});
+
+describe("isPlayerComplete", () => {
+  it("returns true when all categories filled", () => {
+    const player = createPlayer({
+      ones: 3,
+      twos: 6,
+      threes: 9,
+      fours: 12,
+      fives: 15,
+      sixes: 18,
+      threeOfAKind: 15,
+      fourOfAKind: 20,
+      fullHouse: 25,
+      smallStraight: 30,
+      largeStraight: 40,
+      kniffel: 50,
+      chance: 20,
+    });
+    expect(isPlayerComplete(player)).toBe(true);
+  });
+
+  it("returns false when any category is null", () => {
+    const player = createPlayer({
+      ones: 3,
+      twos: 6,
+      threes: 9,
+      fours: 12,
+      fives: 15,
+      sixes: 18,
+      threeOfAKind: 15,
+      fourOfAKind: 20,
+      fullHouse: 25,
+      smallStraight: 30,
+      largeStraight: 40,
+      kniffel: null,
+      chance: 20,
+    });
+    expect(isPlayerComplete(player)).toBe(false);
+  });
+});
+
+describe("getWinners", () => {
+  it("returns single winner", () => {
+    const players = [
+      createPlayer({
+        ones: 5,
+        twos: 0,
+        threes: 0,
+        fours: 0,
+        fives: 0,
+        sixes: 0,
+      }),
+      createPlayer({
+        ones: 3,
+        twos: 0,
+        threes: 0,
+        fours: 0,
+        fives: 0,
+        sixes: 0,
+      }),
+    ];
+    players[0].name = "Player 1";
+    players[1].name = "Player 2";
+    const winners = getWinners(players);
+    expect(winners).toHaveLength(1);
+    expect(winners[0].name).toBe("Player 1");
+  });
+
+  it("returns multiple winners on tie", () => {
+    const players = [
+      createPlayer({
+        ones: 5,
+        twos: 0,
+        threes: 0,
+        fours: 0,
+        fives: 0,
+        sixes: 0,
+      }),
+      createPlayer({
+        ones: 5,
+        twos: 0,
+        threes: 0,
+        fours: 0,
+        fives: 0,
+        sixes: 0,
+      }),
+    ];
+    players[0].name = "Player 1";
+    players[1].name = "Player 2";
+    const winners = getWinners(players);
+    expect(winners).toHaveLength(2);
+  });
+
+  it("returns empty array for no players", () => {
+    expect(getWinners([])).toEqual([]);
+  });
+});

--- a/lib/kniffel/dice.ts
+++ b/lib/kniffel/dice.ts
@@ -1,0 +1,52 @@
+import type { DieState } from "./types";
+import { NUM_DICE } from "./types";
+
+/**
+ * Generate a random die value (1-6)
+ */
+export function randomDieValue(): number {
+  return Math.floor(Math.random() * 6) + 1;
+}
+
+/**
+ * Create initial dice state (all unheld, value 1)
+ */
+export function createInitialDice(): DieState[] {
+  return Array.from({ length: NUM_DICE }, () => ({
+    value: 1,
+    held: false,
+  }));
+}
+
+/**
+ * Roll all unheld dice
+ */
+export function rollDice(dice: DieState[]): DieState[] {
+  return dice.map((die) => ({
+    value: die.held ? die.value : randomDieValue(),
+    held: die.held,
+  }));
+}
+
+/**
+ * Toggle hold state of a specific die
+ */
+export function toggleHold(dice: DieState[], index: number): DieState[] {
+  return dice.map((die, i) =>
+    i === index ? { ...die, held: !die.held } : die,
+  );
+}
+
+/**
+ * Reset all dice to unheld state
+ */
+export function resetHolds(dice: DieState[]): DieState[] {
+  return dice.map((die) => ({ ...die, held: false }));
+}
+
+/**
+ * Check if any dice are held
+ */
+export function hasHeldDice(dice: DieState[]): boolean {
+  return dice.some((die) => die.held);
+}

--- a/lib/kniffel/index.ts
+++ b/lib/kniffel/index.ts
@@ -1,0 +1,3 @@
+export * from "./dice";
+export * from "./scoring";
+export * from "./types";

--- a/lib/kniffel/scoring.ts
+++ b/lib/kniffel/scoring.ts
@@ -1,0 +1,232 @@
+import type { DieState, Player, ScoreCategory } from "./types";
+import {
+  LOWER_CATEGORIES,
+  UPPER_BONUS_THRESHOLD,
+  UPPER_BONUS_VALUE,
+  UPPER_CATEGORIES,
+} from "./types";
+
+/**
+ * Get dice values as an array of numbers
+ */
+export function getDiceValues(dice: DieState[]): number[] {
+  return dice.map((d) => d.value);
+}
+
+/**
+ * Count occurrences of each die value
+ */
+export function countDice(values: number[]): Record<number, number> {
+  const counts: Record<number, number> = {};
+  for (const v of values) {
+    counts[v] = (counts[v] || 0) + 1;
+  }
+  return counts;
+}
+
+/**
+ * Sum all dice values
+ */
+export function sumDice(values: number[]): number {
+  return values.reduce((sum, v) => sum + v, 0);
+}
+
+/**
+ * Calculate score for upper section categories (ones through sixes)
+ */
+export function scoreUpper(values: number[], target: number): number {
+  return values.filter((v) => v === target).reduce((sum, v) => sum + v, 0);
+}
+
+/**
+ * Check if dice contain N of a kind
+ */
+export function hasNOfAKind(values: number[], n: number): boolean {
+  const counts = countDice(values);
+  return Object.values(counts).some((count) => count >= n);
+}
+
+/**
+ * Score three of a kind (sum of all dice if valid)
+ */
+export function scoreThreeOfAKind(values: number[]): number {
+  return hasNOfAKind(values, 3) ? sumDice(values) : 0;
+}
+
+/**
+ * Score four of a kind (sum of all dice if valid)
+ */
+export function scoreFourOfAKind(values: number[]): number {
+  return hasNOfAKind(values, 4) ? sumDice(values) : 0;
+}
+
+/**
+ * Check if dice form a full house (3 of one kind + 2 of another)
+ */
+export function isFullHouse(values: number[]): boolean {
+  const counts = Object.values(countDice(values));
+  return counts.includes(3) && counts.includes(2);
+}
+
+/**
+ * Score full house (25 points if valid)
+ */
+export function scoreFullHouse(values: number[]): number {
+  return isFullHouse(values) ? 25 : 0;
+}
+
+/**
+ * Check if dice contain a small straight (4 consecutive values)
+ */
+export function isSmallStraight(values: number[]): boolean {
+  const unique = [...new Set(values)].sort((a, b) => a - b);
+  const straights = [
+    [1, 2, 3, 4],
+    [2, 3, 4, 5],
+    [3, 4, 5, 6],
+  ];
+  return straights.some((straight) =>
+    straight.every((v) => unique.includes(v)),
+  );
+}
+
+/**
+ * Score small straight (30 points if valid)
+ */
+export function scoreSmallStraight(values: number[]): number {
+  return isSmallStraight(values) ? 30 : 0;
+}
+
+/**
+ * Check if dice form a large straight (5 consecutive values)
+ */
+export function isLargeStraight(values: number[]): boolean {
+  const sorted = [...values].sort((a, b) => a - b);
+  const low = [1, 2, 3, 4, 5];
+  const high = [2, 3, 4, 5, 6];
+  return (
+    sorted.every((v, i) => v === low[i]) ||
+    sorted.every((v, i) => v === high[i])
+  );
+}
+
+/**
+ * Score large straight (40 points if valid)
+ */
+export function scoreLargeStraight(values: number[]): number {
+  return isLargeStraight(values) ? 40 : 0;
+}
+
+/**
+ * Check if dice are a Kniffel (5 of a kind)
+ */
+export function isKniffel(values: number[]): boolean {
+  return hasNOfAKind(values, 5);
+}
+
+/**
+ * Score Kniffel (50 points if valid)
+ */
+export function scoreKniffel(values: number[]): number {
+  return isKniffel(values) ? 50 : 0;
+}
+
+/**
+ * Score chance (sum of all dice)
+ */
+export function scoreChance(values: number[]): number {
+  return sumDice(values);
+}
+
+/**
+ * Calculate potential score for a category given dice values
+ */
+export function calculateScore(
+  category: ScoreCategory,
+  dice: DieState[],
+): number {
+  const values = getDiceValues(dice);
+
+  switch (category) {
+    case "ones":
+      return scoreUpper(values, 1);
+    case "twos":
+      return scoreUpper(values, 2);
+    case "threes":
+      return scoreUpper(values, 3);
+    case "fours":
+      return scoreUpper(values, 4);
+    case "fives":
+      return scoreUpper(values, 5);
+    case "sixes":
+      return scoreUpper(values, 6);
+    case "threeOfAKind":
+      return scoreThreeOfAKind(values);
+    case "fourOfAKind":
+      return scoreFourOfAKind(values);
+    case "fullHouse":
+      return scoreFullHouse(values);
+    case "smallStraight":
+      return scoreSmallStraight(values);
+    case "largeStraight":
+      return scoreLargeStraight(values);
+    case "kniffel":
+      return scoreKniffel(values);
+    case "chance":
+      return scoreChance(values);
+  }
+}
+
+/**
+ * Calculate upper section total for a player
+ */
+export function getUpperTotal(player: Player): number {
+  return UPPER_CATEGORIES.reduce(
+    (sum, cat) => sum + (player.scores[cat] ?? 0),
+    0,
+  );
+}
+
+/**
+ * Calculate upper section bonus for a player
+ */
+export function getUpperBonus(player: Player): number {
+  return getUpperTotal(player) >= UPPER_BONUS_THRESHOLD ? UPPER_BONUS_VALUE : 0;
+}
+
+/**
+ * Calculate lower section total for a player
+ */
+export function getLowerTotal(player: Player): number {
+  return LOWER_CATEGORIES.reduce(
+    (sum, cat) => sum + (player.scores[cat] ?? 0),
+    0,
+  );
+}
+
+/**
+ * Calculate grand total for a player
+ */
+export function getGrandTotal(player: Player): number {
+  return getUpperTotal(player) + getUpperBonus(player) + getLowerTotal(player);
+}
+
+/**
+ * Check if a player has completed all categories
+ */
+export function isPlayerComplete(player: Player): boolean {
+  return (
+    UPPER_CATEGORIES.every((cat) => player.scores[cat] !== null) &&
+    LOWER_CATEGORIES.every((cat) => player.scores[cat] !== null)
+  );
+}
+
+/**
+ * Get the winner(s) from a list of players
+ */
+export function getWinners(players: Player[]): Player[] {
+  if (players.length === 0) return [];
+
+  const maxScore = Math.max(...players.map(getGrandTotal));
+  return players.filter((p) => getGrandTotal(p) === maxScore);
+}

--- a/lib/kniffel/types.ts
+++ b/lib/kniffel/types.ts
@@ -1,0 +1,83 @@
+export type ScoreCategory =
+  // Upper section
+  | "ones"
+  | "twos"
+  | "threes"
+  | "fours"
+  | "fives"
+  | "sixes"
+  // Lower section
+  | "threeOfAKind"
+  | "fourOfAKind"
+  | "fullHouse"
+  | "smallStraight"
+  | "largeStraight"
+  | "kniffel"
+  | "chance";
+
+export const UPPER_CATEGORIES: ScoreCategory[] = [
+  "ones",
+  "twos",
+  "threes",
+  "fours",
+  "fives",
+  "sixes",
+];
+
+export const LOWER_CATEGORIES: ScoreCategory[] = [
+  "threeOfAKind",
+  "fourOfAKind",
+  "fullHouse",
+  "smallStraight",
+  "largeStraight",
+  "kniffel",
+  "chance",
+];
+
+export const ALL_CATEGORIES: ScoreCategory[] = [
+  ...UPPER_CATEGORIES,
+  ...LOWER_CATEGORIES,
+];
+
+export interface DieState {
+  value: number; // 1-6
+  held: boolean;
+}
+
+export interface Player {
+  id: string;
+  name: string;
+  scores: Record<ScoreCategory, number | null>;
+}
+
+export type GameMode = "digital" | "tracker";
+export type GamePhase = "mode-select" | "setup" | "playing" | "finished";
+
+export interface GameState {
+  mode: GameMode | null;
+  phase: GamePhase;
+  players: Player[];
+  currentPlayerIndex: number;
+  currentTurn: number; // 1-13
+  dice: DieState[];
+  rollsRemaining: number; // 0-3
+  hasRolled: boolean;
+}
+
+export interface StoredGameState {
+  mode: GameMode;
+  phase: GamePhase;
+  players: Player[];
+  currentPlayerIndex: number;
+  currentTurn: number;
+  dice: DieState[];
+  rollsRemaining: number;
+  hasRolled: boolean;
+  timestamp: number;
+}
+
+export const TOTAL_TURNS = 13;
+export const MAX_ROLLS = 3;
+export const NUM_DICE = 5;
+export const UPPER_BONUS_THRESHOLD = 63;
+export const UPPER_BONUS_VALUE = 35;

--- a/messages/de.json
+++ b/messages/de.json
@@ -63,6 +63,12 @@
           "ready": "Bereit zum Lösen"
         }
       }
+    },
+    "kniffel": {
+      "title": "Kniffel",
+      "description": "Klassisches Würfelspiel für 1-6 Spieler",
+      "play": "Spielen",
+      "instructions": "Würfle und sammle Punkte mit Kombinationen. Spiele digital oder nutze es als Tracker für echte Würfel."
     }
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -63,6 +63,12 @@
           "ready": "Ready to solve"
         }
       }
+    },
+    "kniffel": {
+      "title": "Kniffel",
+      "description": "Classic dice game for 1-6 players",
+      "play": "Play",
+      "instructions": "Roll dice and score combinations. Play digitally or use as a tracker for physical dice."
     }
   }
 }

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,11 +1,13 @@
 import createMiddleware from "next-intl/middleware";
 import { defaultLocale, locales } from "./i18n/config";
 
-export default createMiddleware({
+const intlMiddleware = createMiddleware({
   locales,
   defaultLocale,
   localePrefix: "always",
 });
+
+export const proxy = intlMiddleware;
 
 export const config = {
   matcher: ["/", "/(en|de)/:path*"],


### PR DESCRIPTION
## Summary

- **Kniffel/Yahtzee game**: Classic dice game with two modes:
  - **Digital mode**: Virtual dice rolling with automatic scoring
  - **Tracker mode**: Manual score entry for physical dice games
  - Supports 1-6 players with localStorage persistence
  - Full bilingual support (EN/DE)

- **Wordle improvements**:
  - Mobile keyboard support (tap board to activate native keyboard)
  - Toggleable on-screen keyboard (persisted preference)
  - Fixed German keyboard width with compact layout
  - Added back navigation link

- **Wordle Solver improvements**:
  - Mobile keyboard support (tap grid to activate native keyboard)
  - Toggleable on-screen keyboard

- **Other fixes**:
  - Header now has background color for proper scroll behavior
  - Migrated middleware.ts to proxy.ts for Next.js 16
  - Added back navigation to all game pages

## Test plan

- [ ] Test Kniffel digital mode: roll dice, hold, score categories
- [ ] Test Kniffel tracker mode: manual entry for all categories
- [ ] Test Kniffel persistence: refresh page, game state restored
- [ ] Test Wordle on mobile: tap board, native keyboard appears
- [ ] Test Wordle keyboard toggle: hide/show on-screen keyboard
- [ ] Test Wordle Solver on mobile: tap grid, native keyboard appears
- [ ] Test Wordle Solver keyboard toggle
- [ ] Test back navigation on all game pages
- [ ] Test both locales (EN/DE)
- [ ] Verify header doesn't show text overlap when scrolling

Generated with Claude Code