### PR TITLE
feat: add scientifically-grounded pomodoro timer tool

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -57,7 +57,12 @@
       "Bash(grep:*)",
       "Bash(tree:*)",
       "Bash(gh pr diff:*)",
-      "Bash(gh api:*)"
+      "Bash(gh api:*)",
+      "Bash(wc:*)",
+      "Bash(jj git init:*)",
+      "Bash(jj file show:*)",
+      "Bash(bunx vitest run:*)"
     ]
-  }
+  },
+  "outputStyle": "default"
 }

--- a/app/[locale]/tools/page.tsx
+++ b/app/[locale]/tools/page.tsx
@@ -1,0 +1,31 @@
+import Link from "next/link";
+import { getTranslations } from "next-intl/server";
+import { Button } from "@/components/ui/button";
+
+export default async function ToolsPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const t = await getTranslations("tools");
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold">{t("title")}</h1>
+        <p className="text-muted-foreground">{t("subtitle")}</p>
+      </div>
+
+      <div className="rounded-2xl border border-border bg-card/60 p-4 shadow-sm">
+        <div className="space-y-3">
+          <h2 className="text-xl font-semibold">{t("pomodoro.title")}</h2>
+          <p className="text-muted-foreground">{t("pomodoro.description")}</p>
+          <Button asChild>
+            <Link href={`/${locale}/tools/pomodoro`}>{t("pomodoro.open")}</Link>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/[locale]/tools/pomodoro/page.tsx
+++ b/app/[locale]/tools/pomodoro/page.tsx
@@ -1,0 +1,17 @@
+import { getTranslations } from "next-intl/server";
+import { PomodoroApp } from "@/components/pomodoro/pomodoro-app";
+
+export default async function PomodoroPage() {
+  const t = await getTranslations("pomodoro");
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold">{t("title")}</h1>
+        <p className="text-muted-foreground">{t("instructions")}</p>
+      </div>
+
+      <PomodoroApp />
+    </div>
+  );
+}

--- a/components/pomodoro/custom-preset-form.tsx
+++ b/components/pomodoro/custom-preset-form.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import type { PresetConfig } from "@/lib/pomodoro/types";
+
+function NumberInput({
+  label,
+  value,
+  onChange,
+  min,
+  max,
+  disabled,
+}: {
+  label: string;
+  value: number;
+  onChange: (v: number) => void;
+  min: number;
+  max: number;
+  disabled?: boolean;
+}) {
+  return (
+    <label className="flex items-center justify-between gap-3">
+      <span className="text-sm text-muted-foreground">{label}</span>
+      <input
+        type="number"
+        min={min}
+        max={max}
+        value={value}
+        disabled={disabled}
+        onChange={(e) => {
+          const n = Number.parseInt(e.target.value, 10);
+          if (!Number.isNaN(n)) onChange(Math.max(min, Math.min(max, n)));
+        }}
+        className="w-20 rounded-lg border border-border bg-card px-2 py-1 text-right text-sm disabled:opacity-50"
+      />
+    </label>
+  );
+}
+
+export function CustomPresetForm({
+  config,
+  onChange,
+  disabled,
+}: {
+  config: PresetConfig;
+  onChange: (c: PresetConfig) => void;
+  disabled?: boolean;
+}) {
+  const t = useTranslations("pomodoro.custom");
+
+  const update = (key: keyof PresetConfig, value: number) => {
+    onChange({ ...config, [key]: value });
+  };
+
+  return (
+    <div className="space-y-2 rounded-xl border border-border bg-card/60 p-4">
+      <NumberInput
+        label={t("workMinutes")}
+        value={config.workMinutes}
+        onChange={(v) => update("workMinutes", v)}
+        min={1}
+        max={120}
+        disabled={disabled}
+      />
+      <NumberInput
+        label={t("breakMinutes")}
+        value={config.breakMinutes}
+        onChange={(v) => update("breakMinutes", v)}
+        min={1}
+        max={60}
+        disabled={disabled}
+      />
+      <NumberInput
+        label={t("longBreakMinutes")}
+        value={config.longBreakMinutes}
+        onChange={(v) => update("longBreakMinutes", v)}
+        min={1}
+        max={60}
+        disabled={disabled}
+      />
+      <NumberInput
+        label={t("sessionsBeforeLongBreak")}
+        value={config.sessionsBeforeLongBreak}
+        onChange={(v) => update("sessionsBeforeLongBreak", v)}
+        min={1}
+        max={12}
+        disabled={disabled}
+      />
+    </div>
+  );
+}

--- a/components/pomodoro/pomodoro-app.tsx
+++ b/components/pomodoro/pomodoro-app.tsx
@@ -1,0 +1,589 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { PRESETS } from "@/lib/pomodoro/constants";
+import {
+  requestPermission,
+  sendNotification,
+} from "@/lib/pomodoro/notifications";
+import {
+  generateSchedule,
+  getPeakFocusInfo,
+  scheduleFromTimeRange,
+  suggestBetterPreset,
+} from "@/lib/pomodoro/scheduler";
+import {
+  clearTimerState,
+  getDefaultCustomConfig,
+  loadStats,
+  loadTimerState,
+  saveStats,
+  saveTimerState,
+  upsertTodayStats,
+} from "@/lib/pomodoro/storage";
+import type {
+  PresetConfig,
+  PresetId,
+  Schedule,
+  SessionRecord,
+  TimerState,
+} from "@/lib/pomodoro/types";
+import { CustomPresetForm } from "./custom-preset-form";
+import { PresetSelector } from "./preset-selector";
+import { ScheduleView } from "./schedule-view";
+import { SessionTrack } from "./session-track";
+import { SourcesSection } from "./sources-section";
+import { StatsPanel } from "./stats-panel";
+import { TimerDisplay } from "./timer-display";
+
+type SchedulingMode = "sessions" | "focusUntil";
+
+const DEFAULT_SESSION_COUNT = 4;
+
+function getDefaultEndTime(): string {
+  const d = new Date();
+  d.setHours(d.getHours() + 2, 0, 0, 0);
+  return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+}
+
+function getActivePreset(
+  presetId: PresetId,
+  customConfig: PresetConfig,
+): PresetConfig {
+  return presetId === "custom" ? customConfig : PRESETS[presetId];
+}
+
+export function PomodoroApp() {
+  const tNotif = useTranslations("pomodoro.notifications");
+  const tTimer = useTranslations("pomodoro.timer");
+  const tSessions = useTranslations("pomodoro.sessions");
+  const tTimeOfDay = useTranslations("pomodoro.timeOfDay");
+  const tFocusUntil = useTranslations("pomodoro.focusUntil");
+  const tPresets = useTranslations("pomodoro.presets");
+
+  // Error state
+  const [endTimeError, setEndTimeError] = useState<string | null>(null);
+
+  // Config state
+  const [presetId, setPresetId] = useState<PresetId>("pomodoro");
+  const [customConfig, setCustomConfig] = useState<PresetConfig>(
+    getDefaultCustomConfig(),
+  );
+  const [sessionCount, setSessionCount] = useState(DEFAULT_SESSION_COUNT);
+  const [schedulingMode, setSchedulingMode] =
+    useState<SchedulingMode>("sessions");
+  const [endTimeStr, setEndTimeStr] = useState(getDefaultEndTime);
+
+  // Schedule & timer
+  const [schedule, setSchedule] = useState<Schedule | null>(null);
+  const [timerState, setTimerState] = useState<TimerState>({
+    phase: "work",
+    currentBlockIndex: 0,
+    remainingSeconds: 0,
+    isRunning: false,
+    completedSessions: 0,
+  });
+
+  // Stats
+  const [stats, setStats] = useState<SessionRecord[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  // Track last completed work block for stats
+  const lastWorkDurationRef = useRef(0);
+
+  // Load from localStorage on mount
+  useEffect(() => {
+    const stored = loadTimerState();
+    if (stored) {
+      setPresetId(stored.presetId);
+      setCustomConfig(stored.customConfig);
+      setSessionCount(stored.sessionCount);
+      setSchedule(stored.schedule);
+
+      // Handle time drift if timer was running
+      let restoredTimer = stored.timerState;
+      if (restoredTimer.isRunning) {
+        const elapsed = Math.floor(
+          (Date.now() - new Date(stored.savedAt).getTime()) / 1000,
+        );
+        restoredTimer = {
+          ...restoredTimer,
+          remainingSeconds: Math.max(
+            0,
+            restoredTimer.remainingSeconds - elapsed,
+          ),
+          isRunning: false, // Pause on restore, let user decide
+        };
+      }
+      setTimerState(restoredTimer);
+    }
+
+    setStats(loadStats());
+    setLoaded(true);
+  }, []);
+
+  // Save timer state on changes
+  useEffect(() => {
+    if (!loaded || !schedule) return;
+    saveTimerState({
+      presetId,
+      customConfig,
+      sessionCount,
+      schedule,
+      timerState,
+      savedAt: new Date().toISOString(),
+    });
+  }, [loaded, presetId, customConfig, sessionCount, schedule, timerState]);
+
+  // Timer interval
+  useEffect(() => {
+    if (!timerState.isRunning || !schedule) return;
+
+    const interval = setInterval(() => {
+      setTimerState((prev) => {
+        if (prev.remainingSeconds <= 1) {
+          const currentBlock = schedule.blocks[prev.currentBlockIndex];
+          const nextIndex = prev.currentBlockIndex + 1;
+          const wasWork = currentBlock?.phase === "work";
+
+          // Track work duration for stats
+          if (wasWork && currentBlock) {
+            lastWorkDurationRef.current = currentBlock.durationSeconds;
+          }
+
+          if (nextIndex >= schedule.blocks.length) {
+            // All done
+            sendNotification("Pomodoro", tNotif("allDone"));
+            return {
+              ...prev,
+              remainingSeconds: 0,
+              isRunning: false,
+              completedSessions: wasWork
+                ? prev.completedSessions + 1
+                : prev.completedSessions,
+            };
+          }
+
+          const nextBlock = schedule.blocks[nextIndex];
+          if (!nextBlock) {
+            return { ...prev, remainingSeconds: 0, isRunning: false };
+          }
+
+          // Send notification
+          if (wasWork) {
+            sendNotification("Pomodoro", tNotif("workDone"));
+          } else {
+            sendNotification("Pomodoro", tNotif("breakDone"));
+          }
+
+          return {
+            phase: nextBlock.phase,
+            currentBlockIndex: nextIndex,
+            remainingSeconds: nextBlock.durationSeconds,
+            isRunning: true,
+            completedSessions: wasWork
+              ? prev.completedSessions + 1
+              : prev.completedSessions,
+          };
+        }
+        return { ...prev, remainingSeconds: prev.remainingSeconds - 1 };
+      });
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [timerState.isRunning, schedule, tNotif]);
+
+  // Record stats when a work session completes
+  const prevCompletedRef = useRef(0);
+  const presetIdRef = useRef(presetId);
+  presetIdRef.current = presetId;
+
+  useEffect(() => {
+    if (!loaded) return;
+    if (timerState.completedSessions > prevCompletedRef.current) {
+      const workDuration = lastWorkDurationRef.current;
+      setStats((prev) => {
+        const updated = upsertTodayStats(
+          prev,
+          presetIdRef.current,
+          workDuration,
+          0,
+        );
+        saveStats(updated);
+        return updated;
+      });
+    }
+    prevCompletedRef.current = timerState.completedSessions;
+  }, [timerState.completedSessions, loaded]);
+
+  // Handlers
+  const handleGenerateSchedule = useCallback(() => {
+    const preset = getActivePreset(presetId, customConfig);
+    const now = new Date();
+    let newSchedule: Schedule;
+
+    if (schedulingMode === "focusUntil") {
+      const [hours, minutes] = endTimeStr.split(":").map(Number);
+      const endTime = new Date();
+      endTime.setHours(hours ?? 0, minutes ?? 0, 0, 0);
+      if (endTime <= now) {
+        setEndTimeError(tFocusUntil("pastTime"));
+        return;
+      }
+      setEndTimeError(null);
+      newSchedule = scheduleFromTimeRange(preset, now, endTime);
+      if (newSchedule.blocks.length === 0) {
+        setEndTimeError(tFocusUntil("noFit"));
+        return;
+      }
+    } else {
+      newSchedule = generateSchedule(preset, sessionCount, now);
+    }
+
+    setSchedule(newSchedule);
+    const firstBlock = newSchedule.blocks[0];
+    setTimerState({
+      phase: firstBlock ? firstBlock.phase : "work",
+      currentBlockIndex: 0,
+      remainingSeconds: firstBlock ? firstBlock.durationSeconds : 0,
+      isRunning: false,
+      completedSessions: 0,
+    });
+    requestPermission();
+  }, [
+    presetId,
+    customConfig,
+    sessionCount,
+    schedulingMode,
+    endTimeStr,
+    tFocusUntil,
+  ]);
+
+  const handleStart = useCallback(() => {
+    if (!schedule) {
+      handleGenerateSchedule();
+      // Will start after schedule is set — use effect below
+      return;
+    }
+    setTimerState((prev) => ({ ...prev, isRunning: true }));
+  }, [schedule, handleGenerateSchedule]);
+
+  // Auto-start after generating schedule from handleStart
+  const pendingStartRef = useRef(false);
+  const handleStartAndGenerate = useCallback(() => {
+    if (!schedule) {
+      pendingStartRef.current = true;
+      handleGenerateSchedule();
+    } else {
+      setTimerState((prev) => ({ ...prev, isRunning: true }));
+    }
+  }, [schedule, handleGenerateSchedule]);
+
+  useEffect(() => {
+    if (schedule && pendingStartRef.current) {
+      pendingStartRef.current = false;
+      setTimerState((prev) => ({ ...prev, isRunning: true }));
+    }
+  }, [schedule]);
+
+  const handlePause = useCallback(() => {
+    setTimerState((prev) => ({ ...prev, isRunning: false }));
+  }, []);
+
+  const handleReset = useCallback(() => {
+    setSchedule(null);
+    setTimerState({
+      phase: "work",
+      currentBlockIndex: 0,
+      remainingSeconds: 0,
+      isRunning: false,
+      completedSessions: 0,
+    });
+    clearTimerState();
+  }, []);
+
+  const handleSkip = useCallback(() => {
+    if (!schedule) return;
+    const nextIndex = timerState.currentBlockIndex + 1;
+    if (nextIndex >= schedule.blocks.length) {
+      handleReset();
+      return;
+    }
+    const nextBlock = schedule.blocks[nextIndex];
+    if (!nextBlock) {
+      handleReset();
+      return;
+    }
+    setTimerState((prev) => ({
+      ...prev,
+      phase: nextBlock.phase,
+      currentBlockIndex: nextIndex,
+      remainingSeconds: nextBlock.durationSeconds,
+      completedSessions:
+        prev.phase === "work"
+          ? prev.completedSessions + 1
+          : prev.completedSessions,
+    }));
+  }, [schedule, timerState.currentBlockIndex, handleReset]);
+
+  const handlePresetChange = useCallback(
+    (id: PresetId) => {
+      setPresetId(id);
+      setEndTimeError(null);
+      const preset = id === "custom" ? customConfig : PRESETS[id];
+      setSessionCount(Math.min(DEFAULT_SESSION_COUNT, preset.maxDailySessions));
+      // Reset schedule when preset changes
+      if (schedule && !timerState.isRunning) {
+        setSchedule(null);
+        setTimerState({
+          phase: "work",
+          currentBlockIndex: 0,
+          remainingSeconds: 0,
+          isRunning: false,
+          completedSessions: 0,
+        });
+      }
+    },
+    [schedule, timerState.isRunning, customConfig],
+  );
+
+  const handleSessionCountChange = useCallback(
+    (count: number) => {
+      const preset = getActivePreset(presetId, customConfig);
+      setSessionCount(Math.max(1, Math.min(preset.maxDailySessions, count)));
+    },
+    [presetId, customConfig],
+  );
+
+  const isTimerActive = schedule !== null;
+  const isDone =
+    isTimerActive &&
+    !timerState.isRunning &&
+    timerState.remainingSeconds === 0 &&
+    timerState.currentBlockIndex > 0;
+  const totalSessions = schedule
+    ? schedule.blocks.filter((b) => b.phase === "work").length
+    : sessionCount;
+
+  // Preset suggestion for focusUntil mode
+  const presetSuggestion = useMemo(() => {
+    if (schedulingMode !== "focusUntil" || isTimerActive) return null;
+    const [hours, minutes] = endTimeStr.split(":").map(Number);
+    const now = new Date();
+    const endTime = new Date();
+    endTime.setHours(hours ?? 0, minutes ?? 0, 0, 0);
+    if (endTime <= now) return null;
+    const preset = getActivePreset(presetId, customConfig);
+    return suggestBetterPreset(preset, now, endTime);
+  }, [schedulingMode, endTimeStr, presetId, customConfig, isTimerActive]);
+
+  // Time-of-day hint
+  const peakInfo = getPeakFocusInfo(new Date().getHours());
+  const phaseLabel =
+    timerState.phase === "work"
+      ? tTimer("work")
+      : timerState.phase === "longBreak"
+        ? tTimer("longBreak")
+        : tTimer("break");
+
+  const currentBlock = schedule?.blocks[timerState.currentBlockIndex];
+  const totalSecondsForBlock = currentBlock?.durationSeconds ?? 0;
+
+  return (
+    <div className="space-y-6">
+      {/* Preset selection */}
+      <PresetSelector
+        selected={presetId}
+        onSelect={handlePresetChange}
+        disabled={timerState.isRunning}
+      />
+
+      {/* Custom form */}
+      {presetId === "custom" && (
+        <CustomPresetForm
+          config={customConfig}
+          onChange={setCustomConfig}
+          disabled={timerState.isRunning}
+        />
+      )}
+
+      {/* Scheduling mode toggle */}
+      {!isTimerActive && (
+        <div className="space-y-3">
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => {
+                setSchedulingMode("sessions");
+                setEndTimeError(null);
+              }}
+              className={`flex-1 rounded-lg border px-3 py-1.5 text-sm transition-colors ${
+                schedulingMode === "sessions"
+                  ? "border-primary bg-primary/10 font-medium"
+                  : "border-border hover:bg-accent/50"
+              }`}
+            >
+              {tSessions("label")}
+            </button>
+            <button
+              type="button"
+              onClick={() => setSchedulingMode("focusUntil")}
+              className={`flex-1 rounded-lg border px-3 py-1.5 text-sm transition-colors ${
+                schedulingMode === "focusUntil"
+                  ? "border-primary bg-primary/10 font-medium"
+                  : "border-border hover:bg-accent/50"
+              }`}
+            >
+              {tFocusUntil("label")}
+            </button>
+          </div>
+
+          {schedulingMode === "sessions" ? (
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-muted-foreground">
+                {tSessions("label")}
+              </span>
+              <div className="flex items-center gap-2">
+                <Button
+                  variant="outline"
+                  size="xs"
+                  onClick={() => handleSessionCountChange(sessionCount - 1)}
+                  disabled={sessionCount <= 1}
+                >
+                  -
+                </Button>
+                <span className="w-8 text-center tabular-nums font-medium">
+                  {sessionCount}
+                </span>
+                <Button
+                  variant="outline"
+                  size="xs"
+                  onClick={() => handleSessionCountChange(sessionCount + 1)}
+                  disabled={
+                    sessionCount >=
+                    getActivePreset(presetId, customConfig).maxDailySessions
+                  }
+                >
+                  +
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-1.5">
+              <div className="flex items-center justify-between">
+                <span className="text-sm text-muted-foreground">
+                  {tFocusUntil("endTime")}
+                </span>
+                <input
+                  type="time"
+                  value={endTimeStr}
+                  onChange={(e) => {
+                    setEndTimeStr(e.target.value);
+                    setEndTimeError(null);
+                  }}
+                  className="rounded-lg border border-border bg-card px-3 py-1.5 text-sm"
+                />
+              </div>
+              {endTimeError && (
+                <p className="text-xs text-destructive">{endTimeError}</p>
+              )}
+              {!endTimeError && presetSuggestion && (
+                <div className="flex items-center justify-between rounded-lg bg-accent/50 px-3 py-2">
+                  <span className="text-xs text-muted-foreground">
+                    {tFocusUntil("suggestion", {
+                      preset: tPresets(presetSuggestion.presetId),
+                      minutes: presetSuggestion.focusMinutes,
+                    })}
+                  </span>
+                  <Button
+                    variant="outline"
+                    size="xs"
+                    onClick={() =>
+                      handlePresetChange(presetSuggestion.presetId)
+                    }
+                  >
+                    {tFocusUntil("switch")}
+                  </Button>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Time-of-day hint */}
+      {peakInfo.label && !isTimerActive && (
+        <div className="rounded-lg bg-accent/50 px-3 py-2 text-xs text-muted-foreground">
+          {tTimeOfDay(peakInfo.label)}
+        </div>
+      )}
+
+      {/* Timer display */}
+      {isTimerActive && (
+        <div className="flex flex-col items-center gap-4">
+          <TimerDisplay
+            remainingSeconds={timerState.remainingSeconds}
+            totalSeconds={totalSecondsForBlock}
+            phase={timerState.phase}
+            label={isDone ? tTimer("done") : phaseLabel}
+          />
+
+          <SessionTrack
+            completedSessions={timerState.completedSessions}
+            totalSessions={totalSessions}
+            currentIsWork={timerState.phase === "work" && !isDone}
+          />
+
+          <div className="text-xs text-muted-foreground">
+            {tSessions("completed", {
+              current: timerState.completedSessions,
+              total: totalSessions,
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Controls */}
+      <div className="flex justify-center gap-2">
+        {!isTimerActive && (
+          <Button onClick={handleStartAndGenerate}>{tTimer("start")}</Button>
+        )}
+        {isTimerActive && !isDone && (
+          <>
+            {timerState.isRunning ? (
+              <Button variant="outline" onClick={handlePause}>
+                {tTimer("pause")}
+              </Button>
+            ) : (
+              <Button onClick={handleStart}>{tTimer("resume")}</Button>
+            )}
+            <Button variant="outline" onClick={handleSkip}>
+              {tTimer("skip")}
+            </Button>
+          </>
+        )}
+        {isTimerActive && (
+          <Button variant="ghost" onClick={handleReset}>
+            {tTimer("reset")}
+          </Button>
+        )}
+      </div>
+
+      {/* Schedule */}
+      {schedule && (
+        <ScheduleView
+          schedule={schedule}
+          currentBlockIndex={timerState.currentBlockIndex}
+        />
+      )}
+
+      {/* Stats */}
+      {loaded && <StatsPanel records={stats} />}
+
+      {/* Sources */}
+      <SourcesSection />
+    </div>
+  );
+}

--- a/components/pomodoro/preset-selector.tsx
+++ b/components/pomodoro/preset-selector.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import type { PresetId } from "@/lib/pomodoro/types";
+
+const PRESET_IDS: PresetId[] = ["pomodoro", "desktime", "deepwork", "custom"];
+
+export function PresetSelector({
+  selected,
+  onSelect,
+  disabled,
+}: {
+  selected: PresetId;
+  onSelect: (id: PresetId) => void;
+  disabled?: boolean;
+}) {
+  const t = useTranslations("pomodoro.presets");
+
+  return (
+    <div className="space-y-3">
+      <div className="grid grid-cols-2 gap-2">
+        {PRESET_IDS.map((id) => (
+          <button
+            key={id}
+            type="button"
+            disabled={disabled}
+            onClick={() => onSelect(id)}
+            className={`rounded-xl border p-3 text-left transition-colors ${
+              selected === id
+                ? "border-primary bg-primary/10"
+                : "border-border bg-card/60 hover:bg-accent/50"
+            } ${disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer"}`}
+          >
+            <div className="text-sm font-medium">{t(id)}</div>
+            <div className="text-xs text-muted-foreground">
+              {t(`${id}Desc`)}
+            </div>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/pomodoro/schedule-view.tsx
+++ b/components/pomodoro/schedule-view.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { validateBreakRatio } from "@/lib/pomodoro/scheduler";
+import type { Schedule } from "@/lib/pomodoro/types";
+import { cn } from "@/lib/utils";
+
+function formatTime(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+export function ScheduleView({
+  schedule,
+  currentBlockIndex,
+}: {
+  schedule: Schedule;
+  currentBlockIndex: number;
+}) {
+  const t = useTranslations("pomodoro.schedule");
+  const { valid, suggestion } = validateBreakRatio(schedule);
+
+  return (
+    <div className="space-y-3">
+      <h3 className="text-sm font-semibold">{t("title")}</h3>
+
+      <div className="space-y-1.5 max-h-48 overflow-y-auto">
+        {schedule.blocks.map((block, i) => {
+          const isCurrent = i === currentBlockIndex;
+          const isPast = i < currentBlockIndex;
+          const minutes = Math.round(block.durationSeconds / 60);
+          const label =
+            block.phase === "work"
+              ? t("session", { number: block.sessionNumber })
+              : block.phase === "longBreak"
+                ? t("longBreakLabel")
+                : t("breakLabel");
+
+          return (
+            <div
+              key={`${block.startTime}-${block.phase}`}
+              className={cn(
+                "flex items-center justify-between rounded-lg px-3 py-1.5 text-sm",
+                isCurrent && "bg-primary/10 font-medium",
+                isPast && "text-muted-foreground line-through opacity-60",
+                !isCurrent && !isPast && "text-foreground",
+              )}
+            >
+              <span className="flex items-center gap-2">
+                <span
+                  className={cn(
+                    "h-2 w-2 rounded-full",
+                    block.phase === "work" && "bg-primary",
+                    block.phase === "break" && "bg-chart-2",
+                    block.phase === "longBreak" && "bg-chart-4",
+                  )}
+                />
+                {label}
+              </span>
+              <span className="tabular-nums text-muted-foreground">
+                {t("duration", { minutes })} · {formatTime(block.startTime)}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="space-y-1 border-t border-border pt-2 text-xs text-muted-foreground">
+        <div>{t("totalWork", { minutes: schedule.totalWorkMinutes })}</div>
+        <div>{t("totalBreak", { minutes: schedule.totalBreakMinutes })}</div>
+        <div>
+          {t("ratio", {
+            percent: Math.round(schedule.breakToWorkRatio * 100),
+          })}{" "}
+          <span className={valid ? "text-chart-2" : "text-chart-5"}>
+            {t(suggestion)}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/pomodoro/session-track.tsx
+++ b/components/pomodoro/session-track.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+export function SessionTrack({
+  completedSessions,
+  totalSessions,
+  currentIsWork,
+}: {
+  completedSessions: number;
+  totalSessions: number;
+  currentIsWork: boolean;
+}) {
+  const dots = [];
+  for (let i = 0; i < totalSessions; i++) {
+    const isCompleted = i < completedSessions;
+    const isCurrent = i === completedSessions && currentIsWork;
+    dots.push(
+      <div
+        key={`s${i}`}
+        className={cn(
+          "h-3 w-3 rounded-full transition-colors",
+          isCompleted && "bg-primary",
+          isCurrent &&
+            "bg-primary/50 ring-2 ring-primary ring-offset-2 ring-offset-background",
+          !isCompleted && !isCurrent && "bg-muted",
+        )}
+      />,
+    );
+  }
+
+  return <div className="flex items-center justify-center gap-2">{dots}</div>;
+}

--- a/components/pomodoro/sources-section.tsx
+++ b/components/pomodoro/sources-section.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+
+const SOURCES = [
+  {
+    key: "pomodoroTechnique",
+    descKey: "pomodoroDesc",
+    url: "https://francescocirillo.com/products/the-pomodoro-technique",
+  },
+  {
+    key: "desktime",
+    descKey: "desktimeDesc",
+    url: "https://desktime.com/blog/52-17-updated",
+  },
+  {
+    key: "ultradian",
+    descKey: "ultradianDesc",
+    url: "https://en.wikipedia.org/wiki/Basic_rest%E2%80%93activity_cycle",
+  },
+  {
+    key: "huberman",
+    descKey: "hubermanDesc",
+    url: "https://www.hubermanlab.com/episode/focus-toolkit-tools-to-improve-your-focus-and-concentration",
+  },
+  {
+    key: "microbreaks",
+    descKey: "microbreaksDesc",
+    url: "https://pmc.ncbi.nlm.nih.gov/articles/PMC9432722/",
+  },
+  {
+    key: "breakRatio",
+    descKey: "breakRatioDesc",
+    url: "https://chrisbailey.com/for-optimal-productivity-be-on-break-for-20-25-of-the-workday/",
+  },
+] as const;
+
+export function SourcesSection() {
+  const t = useTranslations("pomodoro.sources");
+
+  return (
+    <details className="rounded-xl border border-border bg-card/60 p-4">
+      <summary className="cursor-pointer text-sm font-semibold">
+        <span className="ml-1">{t("title")}</span>
+      </summary>
+      <ul className="mt-3 space-y-3">
+        {SOURCES.map(({ key, descKey, url }) => (
+          <li key={key}>
+            <a
+              href={url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm font-medium text-primary underline underline-offset-2 hover:text-primary/80"
+            >
+              {t(key)}
+            </a>
+            <p className="text-xs text-muted-foreground">{t(descKey)}</p>
+          </li>
+        ))}
+      </ul>
+    </details>
+  );
+}

--- a/components/pomodoro/stats-panel.tsx
+++ b/components/pomodoro/stats-panel.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import type { SessionRecord } from "@/lib/pomodoro/types";
+
+function computeStreak(records: SessionRecord[]): number {
+  if (records.length === 0) return 0;
+
+  const sorted = [...records].sort((a, b) => b.date.localeCompare(a.date));
+  const today = new Date().toISOString().slice(0, 10);
+
+  // Start from today or yesterday
+  let streak = 0;
+  const checkDate = new Date();
+
+  // If today has no record, start from yesterday
+  if (sorted[0]?.date !== today) {
+    checkDate.setDate(checkDate.getDate() - 1);
+  }
+
+  for (let i = 0; i < 365; i++) {
+    const dateStr = checkDate.toISOString().slice(0, 10);
+    if (sorted.some((r) => r.date === dateStr && r.sessionsCompleted > 0)) {
+      streak++;
+      checkDate.setDate(checkDate.getDate() - 1);
+    } else {
+      break;
+    }
+  }
+
+  return streak;
+}
+
+export function StatsPanel({ records }: { records: SessionRecord[] }) {
+  const t = useTranslations("pomodoro.stats");
+
+  if (records.length === 0) {
+    return <p className="text-sm text-muted-foreground">{t("noData")}</p>;
+  }
+
+  const today = new Date().toISOString().slice(0, 10);
+  const todayRecord = records.find((r) => r.date === today);
+  const streak = computeStreak(records);
+  const totalSessions = records.reduce(
+    (sum, r) => sum + r.sessionsCompleted,
+    0,
+  );
+  const totalHours = Math.round(
+    records.reduce((sum, r) => sum + r.totalFocusSeconds, 0) / 3600,
+  );
+
+  return (
+    <details className="rounded-xl border border-border bg-card/60 p-4">
+      <summary className="cursor-pointer text-sm font-semibold">
+        <span className="ml-1">{t("title")}</span>
+      </summary>
+      <div className="mt-3 space-y-1 text-sm text-muted-foreground">
+        <div>
+          {t("today")}:{" "}
+          {todayRecord
+            ? `${t("sessionsToday", { count: todayRecord.sessionsCompleted })} · ${t("focusToday", { minutes: Math.round(todayRecord.totalFocusSeconds / 60) })}`
+            : t("noData")}
+        </div>
+        {streak > 0 && <div>{t("streak", { days: streak })}</div>}
+        <div>
+          {t("allTime", { sessions: totalSessions, hours: totalHours })}
+        </div>
+      </div>
+    </details>
+  );
+}

--- a/components/pomodoro/timer-display.tsx
+++ b/components/pomodoro/timer-display.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import type { Phase } from "@/lib/pomodoro/types";
+import { cn } from "@/lib/utils";
+
+const RADIUS = 90;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+
+function formatTime(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+}
+
+function phaseStroke(phase: Phase): string {
+  switch (phase) {
+    case "work":
+      return "stroke-primary";
+    case "break":
+      return "stroke-chart-2";
+    case "longBreak":
+      return "stroke-chart-4";
+  }
+}
+
+export function TimerDisplay({
+  remainingSeconds,
+  totalSeconds,
+  phase,
+  label,
+}: {
+  remainingSeconds: number;
+  totalSeconds: number;
+  phase: Phase;
+  label: string;
+}) {
+  const progress = totalSeconds > 0 ? remainingSeconds / totalSeconds : 0;
+  const offset = CIRCUMFERENCE * (1 - progress);
+
+  return (
+    <div className="flex flex-col items-center gap-2">
+      <svg
+        viewBox="0 0 200 200"
+        className="h-48 w-48 sm:h-56 sm:w-56"
+        aria-hidden="true"
+      >
+        <circle
+          cx="100"
+          cy="100"
+          r={RADIUS}
+          fill="none"
+          className="stroke-muted"
+          strokeWidth="8"
+        />
+        <circle
+          cx="100"
+          cy="100"
+          r={RADIUS}
+          fill="none"
+          className={cn(
+            phaseStroke(phase),
+            "transition-[stroke-dashoffset] duration-1000 ease-linear",
+          )}
+          strokeWidth="8"
+          strokeLinecap="round"
+          strokeDasharray={CIRCUMFERENCE}
+          strokeDashoffset={offset}
+          transform="rotate(-90 100 100)"
+        />
+        <text
+          x="100"
+          y="100"
+          textAnchor="middle"
+          dominantBaseline="central"
+          className="fill-foreground text-4xl font-mono font-bold"
+          style={{ fontSize: "36px" }}
+        >
+          {formatTime(remainingSeconds)}
+        </text>
+      </svg>
+      <span className="text-sm font-medium text-muted-foreground">{label}</span>
+    </div>
+  );
+}

--- a/components/site-nav.tsx
+++ b/components/site-nav.tsx
@@ -74,6 +74,14 @@ export function SiteNav() {
           >
             {t("games")}
           </Link>
+          <Link
+            href={`/${locale}/tools`}
+            className="block rounded-md px-2 py-1 text-sm hover:bg-accent"
+            onClick={() => setMenuOpen(false)}
+            role="menuitem"
+          >
+            {t("tools")}
+          </Link>
         </div>
       )}
     </div>

--- a/lib/pomodoro/__tests__/scheduler.test.ts
+++ b/lib/pomodoro/__tests__/scheduler.test.ts
@@ -1,0 +1,429 @@
+import { describe, expect, it } from "vitest";
+import { PRESETS } from "../constants";
+import {
+  generateSchedule,
+  getPeakFocusInfo,
+  scheduleFromTimeRange,
+  suggestBetterPreset,
+  validateBreakRatio,
+} from "../scheduler";
+
+const pomodoro = PRESETS.pomodoro;
+const desktime = PRESETS.desktime;
+const deepwork = PRESETS.deepwork;
+
+function makeDate(hour: number, minute = 0): Date {
+  const d = new Date(2026, 1, 6, hour, minute, 0, 0);
+  return d;
+}
+
+describe("generateSchedule", () => {
+  it("creates correct number of work blocks", () => {
+    const schedule = generateSchedule(pomodoro, 4, makeDate(9));
+    const workBlocks = schedule.blocks.filter((b) => b.phase === "work");
+    expect(workBlocks.length).toBe(4);
+  });
+
+  it("creates break blocks between work blocks", () => {
+    const schedule = generateSchedule(pomodoro, 4, makeDate(9));
+    // 4 work + 3 breaks = 7 blocks
+    expect(schedule.blocks.length).toBe(7);
+  });
+
+  it("creates a single block for sessionCount=1 (no breaks)", () => {
+    const schedule = generateSchedule(pomodoro, 1, makeDate(9));
+    expect(schedule.blocks.length).toBe(1);
+    expect(schedule.blocks[0]?.phase).toBe("work");
+    expect(schedule.totalBreakMinutes).toBe(0);
+  });
+
+  it("assigns correct work duration", () => {
+    const schedule = generateSchedule(pomodoro, 2, makeDate(9));
+    const workBlocks = schedule.blocks.filter((b) => b.phase === "work");
+    for (const block of workBlocks) {
+      expect(block.durationSeconds).toBe(25 * 60);
+    }
+  });
+
+  it("creates long break at the correct interval", () => {
+    const schedule = generateSchedule(pomodoro, 5, makeDate(9));
+    const breakBlocks = schedule.blocks.filter((b) => b.phase !== "work");
+    const longBreaks = schedule.blocks.filter((b) => b.phase === "longBreak");
+    expect(longBreaks.length).toBe(1);
+    expect(breakBlocks.length).toBe(4);
+  });
+
+  it("applies fatigue multiplier to breaks in later cycles", () => {
+    const schedule = generateSchedule(pomodoro, 8, makeDate(9));
+    const breaks = schedule.blocks.filter(
+      (b) => b.phase === "break" || b.phase === "longBreak",
+    );
+
+    const firstBreak = breaks[0];
+    expect(firstBreak?.durationSeconds).toBe(firstBreak?.baseDurationSeconds);
+
+    const fifthWorkIndex = schedule.blocks.findIndex(
+      (b) => b.phase === "work" && b.sessionNumber === 5,
+    );
+    const breakAfterFifth = schedule.blocks[fifthWorkIndex + 1];
+    if (breakAfterFifth) {
+      expect(breakAfterFifth.durationSeconds).toBeGreaterThan(
+        breakAfterFifth.baseDurationSeconds,
+      );
+    }
+  });
+
+  it("caps fatigue multiplier at 1.5x", () => {
+    const manyShortCycles = {
+      ...pomodoro,
+      sessionsBeforeLongBreak: 1,
+      maxDailySessions: 20,
+    };
+    const schedule = generateSchedule(manyShortCycles, 20, makeDate(9));
+    const breaks = schedule.blocks.filter((b) => b.phase !== "work");
+
+    for (const b of breaks) {
+      const ratio = b.durationSeconds / b.baseDurationSeconds;
+      expect(ratio).toBeLessThanOrEqual(1.5 + 0.01);
+    }
+  });
+
+  it("computes correct totals", () => {
+    const schedule = generateSchedule(pomodoro, 2, makeDate(9));
+    expect(schedule.totalWorkMinutes).toBe(50);
+    expect(schedule.totalBreakMinutes).toBe(5);
+  });
+
+  it("computes break-to-work ratio", () => {
+    const schedule = generateSchedule(pomodoro, 2, makeDate(9));
+    const expectedRatio = (5 * 60) / (50 * 60);
+    expect(schedule.breakToWorkRatio).toBeCloseTo(expectedRatio, 4);
+  });
+
+  it("assigns sequential start times", () => {
+    const schedule = generateSchedule(pomodoro, 3, makeDate(9));
+    for (let i = 1; i < schedule.blocks.length; i++) {
+      const prev = schedule.blocks[i - 1];
+      const curr = schedule.blocks[i];
+      if (!prev || !curr) continue;
+      const prevEnd =
+        new Date(prev.startTime).getTime() + prev.durationSeconds * 1000;
+      expect(new Date(curr.startTime).getTime()).toBe(prevEnd);
+    }
+  });
+});
+
+describe("scheduleFromTimeRange", () => {
+  it("fits maximum sessions within the time window", () => {
+    const start = makeDate(9, 0);
+    const end = makeDate(11, 0); // 2 hours
+    const schedule = scheduleFromTimeRange(pomodoro, start, end);
+
+    const totalSeconds = schedule.blocks.reduce(
+      (sum, b) => sum + b.durationSeconds,
+      0,
+    );
+    expect(totalSeconds).toBeLessThanOrEqual(2 * 60 * 60);
+    expect(
+      schedule.blocks.filter((b) => b.phase === "work").length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("returns empty schedule when end time equals start time", () => {
+    const time = makeDate(9, 0);
+    const schedule = scheduleFromTimeRange(pomodoro, time, time);
+    expect(schedule.blocks.length).toBe(0);
+    expect(schedule.totalWorkMinutes).toBe(0);
+  });
+
+  it("returns empty schedule when end time is before start time", () => {
+    const start = makeDate(10, 0);
+    const end = makeDate(9, 0);
+    const schedule = scheduleFromTimeRange(pomodoro, start, end);
+    expect(schedule.blocks.length).toBe(0);
+  });
+
+  it("returns at least 1 session when time allows only one work block", () => {
+    const start = makeDate(9, 0);
+    const end = makeDate(9, 30); // 30 min, enough for one 25-min pomodoro
+    const schedule = scheduleFromTimeRange(pomodoro, start, end);
+    const workBlocks = schedule.blocks.filter((b) => b.phase === "work");
+    expect(workBlocks.length).toBe(1);
+  });
+
+  it("fits correct sessions for deep work preset in a 3-hour window", () => {
+    const start = makeDate(9, 0);
+    const end = makeDate(12, 0); // 3 hours = 180 min
+    const schedule = scheduleFromTimeRange(deepwork, start, end);
+    const workBlocks = schedule.blocks.filter((b) => b.phase === "work");
+    // 1 deep work session = 90 min, 2 sessions = 90 + 20 + 90 = 200 min > 180
+    // But with fill: remaining = 90 min, break = 20 min, extra = 70 min >= 10 min
+    // So: 1 full session + break + shortened work = 2 work blocks
+    expect(workBlocks.length).toBe(2);
+  });
+
+  it("respects maxDailySessions cap", () => {
+    const start = makeDate(0, 0);
+    const end = makeDate(23, 59); // Almost 24 hours
+    const schedule = scheduleFromTimeRange(deepwork, start, end);
+    const workBlocks = schedule.blocks.filter((b) => b.phase === "work");
+    expect(workBlocks.length).toBeLessThanOrEqual(deepwork.maxDailySessions);
+  });
+
+  it("returns empty schedule when no session fits", () => {
+    const start = makeDate(9, 0);
+    const end = makeDate(9, 10); // Only 10 min, not enough for 25-min pomodoro
+    const schedule = scheduleFromTimeRange(pomodoro, start, end);
+    expect(schedule.blocks.length).toBe(0);
+  });
+});
+
+describe("scheduleFromTimeRange - fill logic", () => {
+  it("fills remaining time with shortened work block", () => {
+    // 52 min window with pomodoro (25 min work, 5 min break)
+    // 1 session = 25 min. Remaining = 27 min. Break = 5 min, extra = 22 min >= 10 min.
+    const start = makeDate(9, 0);
+    const end = makeDate(9, 52);
+    const schedule = scheduleFromTimeRange(pomodoro, start, end);
+    const workBlocks = schedule.blocks.filter((b) => b.phase === "work");
+
+    expect(workBlocks.length).toBe(2);
+    expect(workBlocks[0]?.durationSeconds).toBe(25 * 60); // full session
+    expect(workBlocks[1]?.durationSeconds).toBe(22 * 60); // shortened fill
+  });
+
+  it("does not fill when remaining time is too short", () => {
+    // 35 min window with pomodoro: 1 session = 25 min. Remaining = 10 min.
+    // Break = 5 min, extra = 5 min < 10 min minimum. No fill.
+    const start = makeDate(9, 0);
+    const end = makeDate(9, 35);
+    const schedule = scheduleFromTimeRange(pomodoro, start, end);
+    const workBlocks = schedule.blocks.filter((b) => b.phase === "work");
+
+    expect(workBlocks.length).toBe(1);
+  });
+
+  it("adds a break before the fill work block", () => {
+    const start = makeDate(9, 0);
+    const end = makeDate(9, 52);
+    const schedule = scheduleFromTimeRange(pomodoro, start, end);
+
+    // Blocks should be: work, break, work
+    expect(schedule.blocks.length).toBe(3);
+    expect(schedule.blocks[0]?.phase).toBe("work");
+    expect(schedule.blocks[1]?.phase).toBe("break");
+    expect(schedule.blocks[2]?.phase).toBe("work");
+  });
+
+  it("total duration fits within the time window", () => {
+    const start = makeDate(9, 0);
+    const end = makeDate(10, 0); // 60 min
+    const schedule = scheduleFromTimeRange(pomodoro, start, end);
+    const totalSeconds = schedule.blocks.reduce(
+      (sum, b) => sum + b.durationSeconds,
+      0,
+    );
+    expect(totalSeconds).toBeLessThanOrEqual(60 * 60);
+  });
+
+  it("updates totals after fill", () => {
+    const start = makeDate(9, 0);
+    const end = makeDate(9, 52);
+    const schedule = scheduleFromTimeRange(pomodoro, start, end);
+
+    // 25 + 22 = 47 min work, 5 min break
+    expect(schedule.totalWorkMinutes).toBe(47);
+    expect(schedule.totalBreakMinutes).toBe(5);
+  });
+
+  it("fill block has sequential start time", () => {
+    const start = makeDate(9, 0);
+    const end = makeDate(9, 52);
+    const schedule = scheduleFromTimeRange(pomodoro, start, end);
+
+    for (let i = 1; i < schedule.blocks.length; i++) {
+      const prev = schedule.blocks[i - 1];
+      const curr = schedule.blocks[i];
+      if (!prev || !curr) continue;
+      const prevEnd =
+        new Date(prev.startTime).getTime() + prev.durationSeconds * 1000;
+      expect(new Date(curr.startTime).getTime()).toBe(prevEnd);
+    }
+  });
+});
+
+describe("suggestBetterPreset", () => {
+  it("suggests a better preset when significantly more focus is possible", () => {
+    // 55 min window with deep work: 90 min doesn't fit → empty schedule
+    // Pomodoro: 25 + 5 + 20 = 50 min → 45 min focus
+    const start = makeDate(9, 0);
+    const end = makeDate(9, 55);
+    const result = suggestBetterPreset(deepwork, start, end);
+
+    expect(result).not.toBeNull();
+    expect(result?.focusMinutes).toBeGreaterThan(0);
+    expect(result?.currentFocusMinutes).toBe(0);
+  });
+
+  it("returns null when current preset is already optimal", () => {
+    // 30 min window: only pomodoro fits (1 session = 25 min)
+    // DeskTime = 52 min doesn't fit, Deep Work = 90 min doesn't fit
+    const start = makeDate(9, 0);
+    const end = makeDate(9, 30);
+    const result = suggestBetterPreset(pomodoro, start, end);
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when improvement is below threshold", () => {
+    // Large window where all presets perform similarly
+    const start = makeDate(9, 0);
+    const end = makeDate(11, 0); // 2 hours
+    const result = suggestBetterPreset(pomodoro, start, end);
+
+    // If a suggestion exists, improvement should be >= 15%
+    if (result) {
+      const improvement =
+        (result.focusMinutes - result.currentFocusMinutes) /
+        result.currentFocusMinutes;
+      expect(improvement).toBeGreaterThanOrEqual(0.15);
+    }
+  });
+
+  it("never suggests custom preset", () => {
+    const start = makeDate(9, 0);
+    const end = makeDate(10, 0);
+    const result = suggestBetterPreset(pomodoro, start, end);
+
+    if (result) {
+      expect(result.presetId).not.toBe("custom");
+    }
+  });
+
+  it("suggests when current preset produces empty schedule", () => {
+    // 45 min window with deep work (90 min) → empty
+    // Pomodoro should fit fine
+    const start = makeDate(9, 0);
+    const end = makeDate(9, 45);
+    const result = suggestBetterPreset(deepwork, start, end);
+
+    expect(result).not.toBeNull();
+    expect(result?.currentFocusMinutes).toBe(0);
+    expect(result?.focusMinutes).toBeGreaterThan(0);
+  });
+
+  it("returns null for negative time window", () => {
+    const start = makeDate(10, 0);
+    const end = makeDate(9, 0);
+    const result = suggestBetterPreset(pomodoro, start, end);
+
+    expect(result).toBeNull();
+  });
+});
+
+describe("validateBreakRatio", () => {
+  it("returns valid for ratio in 20-25% range", () => {
+    const result = validateBreakRatio({
+      blocks: [],
+      totalWorkMinutes: 100,
+      totalBreakMinutes: 22,
+      breakToWorkRatio: 0.22,
+    });
+    expect(result.valid).toBe(true);
+    expect(result.suggestion).toBe("ratioGood");
+  });
+
+  it("returns breaksTooShort for ratio below 20%", () => {
+    const result = validateBreakRatio({
+      blocks: [],
+      totalWorkMinutes: 100,
+      totalBreakMinutes: 10,
+      breakToWorkRatio: 0.1,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.suggestion).toBe("breaksTooShort");
+  });
+
+  it("returns breaksTooLong for ratio above 25%", () => {
+    const result = validateBreakRatio({
+      blocks: [],
+      totalWorkMinutes: 100,
+      totalBreakMinutes: 40,
+      breakToWorkRatio: 0.4,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.suggestion).toBe("breaksTooLong");
+  });
+
+  it("returns valid at exact boundary 0.2", () => {
+    const result = validateBreakRatio({
+      blocks: [],
+      totalWorkMinutes: 100,
+      totalBreakMinutes: 20,
+      breakToWorkRatio: 0.2,
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it("returns valid at exact boundary 0.25", () => {
+    const result = validateBreakRatio({
+      blocks: [],
+      totalWorkMinutes: 100,
+      totalBreakMinutes: 25,
+      breakToWorkRatio: 0.25,
+    });
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe("getPeakFocusInfo", () => {
+  it("returns peak focus for morning hours (8-10)", () => {
+    expect(getPeakFocusInfo(8).isPeak).toBe(true);
+    expect(getPeakFocusInfo(9).isPeak).toBe(true);
+    expect(getPeakFocusInfo(10).isPeak).toBe(true);
+    expect(getPeakFocusInfo(8).label).toBe("peakFocus");
+  });
+
+  it("returns afternoon dip for hours 14-15", () => {
+    expect(getPeakFocusInfo(14).isPeak).toBe(false);
+    expect(getPeakFocusInfo(15).isPeak).toBe(false);
+    expect(getPeakFocusInfo(14).label).toBe("afternoonDip");
+  });
+
+  it("returns no label for other hours", () => {
+    expect(getPeakFocusInfo(12).label).toBe("");
+    expect(getPeakFocusInfo(20).label).toBe("");
+    expect(getPeakFocusInfo(7).label).toBe("");
+  });
+
+  it("returns not peak at boundary hour 11", () => {
+    expect(getPeakFocusInfo(11).isPeak).toBe(false);
+    expect(getPeakFocusInfo(11).label).toBe("");
+  });
+});
+
+describe("preset-specific schedules", () => {
+  it("desktime: all breaks are regular (sessionsBeforeLongBreak=1)", () => {
+    const schedule = generateSchedule(desktime, 3, makeDate(9));
+    const breaks = schedule.blocks.filter((b) => b.phase !== "work");
+    for (const b of breaks) {
+      expect(b.phase).toBe("longBreak");
+    }
+  });
+
+  it("desktime: work blocks are 52 minutes", () => {
+    const schedule = generateSchedule(desktime, 2, makeDate(9));
+    const workBlocks = schedule.blocks.filter((b) => b.phase === "work");
+    for (const b of workBlocks) {
+      expect(b.durationSeconds).toBe(52 * 60);
+    }
+  });
+
+  it("deepwork: work blocks are 90 minutes", () => {
+    const schedule = generateSchedule(deepwork, 2, makeDate(9));
+    const workBlocks = schedule.blocks.filter((b) => b.phase === "work");
+    for (const b of workBlocks) {
+      expect(b.durationSeconds).toBe(90 * 60);
+    }
+  });
+});

--- a/lib/pomodoro/constants.ts
+++ b/lib/pomodoro/constants.ts
@@ -1,0 +1,44 @@
+import type { PresetConfig, PresetId } from "./types";
+
+export const PRESETS: Record<PresetId, PresetConfig> = {
+  pomodoro: {
+    id: "pomodoro",
+    workMinutes: 25,
+    breakMinutes: 5,
+    longBreakMinutes: 20,
+    sessionsBeforeLongBreak: 4,
+    maxDailySessions: 8,
+  },
+  desktime: {
+    id: "desktime",
+    workMinutes: 52,
+    breakMinutes: 17,
+    longBreakMinutes: 17,
+    sessionsBeforeLongBreak: 1,
+    maxDailySessions: 5,
+  },
+  deepwork: {
+    id: "deepwork",
+    workMinutes: 90,
+    breakMinutes: 20,
+    longBreakMinutes: 30,
+    sessionsBeforeLongBreak: 1,
+    maxDailySessions: 3,
+  },
+  custom: {
+    id: "custom",
+    workMinutes: 25,
+    breakMinutes: 5,
+    longBreakMinutes: 15,
+    sessionsBeforeLongBreak: 4,
+    maxDailySessions: 8,
+  },
+};
+
+export const FATIGUE_INCREASE_PER_CYCLE = 0.12;
+export const MAX_FATIGUE_MULTIPLIER = 1.5;
+export const TARGET_BREAK_RATIO_MIN = 0.2;
+export const TARGET_BREAK_RATIO_MAX = 0.25;
+export const MIN_EXTRA_WORK_SECONDS = 10 * 60;
+export const SUGGESTION_MIN_IMPROVEMENT = 0.15;
+export const MAX_STATS_DAYS = 90;

--- a/lib/pomodoro/notifications.ts
+++ b/lib/pomodoro/notifications.ts
@@ -1,0 +1,17 @@
+export function canNotify(): boolean {
+  return typeof window !== "undefined" && "Notification" in window;
+}
+
+export async function requestPermission(): Promise<boolean> {
+  if (!canNotify()) return false;
+  if (Notification.permission === "granted") return true;
+  if (Notification.permission === "denied") return false;
+  const result = await Notification.requestPermission();
+  return result === "granted";
+}
+
+export function sendNotification(title: string, body: string): void {
+  if (!canNotify()) return;
+  if (Notification.permission !== "granted") return;
+  new Notification(title, { body, icon: "/favicon.ico" });
+}

--- a/lib/pomodoro/scheduler.ts
+++ b/lib/pomodoro/scheduler.ts
@@ -1,0 +1,236 @@
+import {
+  FATIGUE_INCREASE_PER_CYCLE,
+  MAX_FATIGUE_MULTIPLIER,
+  MIN_EXTRA_WORK_SECONDS,
+  PRESETS,
+  SUGGESTION_MIN_IMPROVEMENT,
+  TARGET_BREAK_RATIO_MAX,
+  TARGET_BREAK_RATIO_MIN,
+} from "./constants";
+import type { PresetConfig, PresetId, Schedule, ScheduleBlock } from "./types";
+
+function computeTotals(blocks: ScheduleBlock[]): {
+  totalWorkMinutes: number;
+  totalBreakMinutes: number;
+  breakToWorkRatio: number;
+} {
+  const totalWorkSeconds = blocks
+    .filter((b) => b.phase === "work")
+    .reduce((sum, b) => sum + b.durationSeconds, 0);
+  const totalBreakSeconds = blocks
+    .filter((b) => b.phase !== "work")
+    .reduce((sum, b) => sum + b.durationSeconds, 0);
+  return {
+    totalWorkMinutes: Math.round(totalWorkSeconds / 60),
+    totalBreakMinutes: Math.round(totalBreakSeconds / 60),
+    breakToWorkRatio:
+      totalWorkSeconds > 0 ? totalBreakSeconds / totalWorkSeconds : 0,
+  };
+}
+
+const EMPTY_SCHEDULE: Schedule = {
+  blocks: [],
+  totalWorkMinutes: 0,
+  totalBreakMinutes: 0,
+  breakToWorkRatio: 0,
+};
+
+export function generateSchedule(
+  preset: PresetConfig,
+  sessionCount: number,
+  startTime: Date,
+): Schedule {
+  const blocks: ScheduleBlock[] = [];
+  let cursor = startTime.getTime();
+
+  for (let i = 1; i <= sessionCount; i++) {
+    const workDuration = preset.workMinutes * 60;
+    blocks.push({
+      phase: "work",
+      durationSeconds: workDuration,
+      baseDurationSeconds: workDuration,
+      startTime: new Date(cursor).toISOString(),
+      sessionNumber: i,
+    });
+    cursor += workDuration * 1000;
+
+    if (i < sessionCount) {
+      const isLongBreak = i % preset.sessionsBeforeLongBreak === 0;
+      const baseBreakMinutes = isLongBreak
+        ? preset.longBreakMinutes
+        : preset.breakMinutes;
+      const baseBreakSeconds = baseBreakMinutes * 60;
+
+      const cyclesSoFar = Math.floor((i - 1) / preset.sessionsBeforeLongBreak);
+      const fatigueMultiplier = Math.min(
+        1 + cyclesSoFar * FATIGUE_INCREASE_PER_CYCLE,
+        MAX_FATIGUE_MULTIPLIER,
+      );
+      const adjustedBreak = Math.round(baseBreakSeconds * fatigueMultiplier);
+
+      blocks.push({
+        phase: isLongBreak ? "longBreak" : "break",
+        durationSeconds: adjustedBreak,
+        baseDurationSeconds: baseBreakSeconds,
+        startTime: new Date(cursor).toISOString(),
+        sessionNumber: 0,
+      });
+      cursor += adjustedBreak * 1000;
+    }
+  }
+
+  return { blocks, ...computeTotals(blocks) };
+}
+
+export function scheduleFromTimeRange(
+  preset: PresetConfig,
+  startTime: Date,
+  endTime: Date,
+): Schedule {
+  const availableSeconds = (endTime.getTime() - startTime.getTime()) / 1000;
+  if (availableSeconds <= 0) {
+    return EMPTY_SCHEDULE;
+  }
+
+  // Find max complete sessions that fit
+  let base: Schedule | null = null;
+  for (
+    let sessionCount = preset.maxDailySessions;
+    sessionCount >= 1;
+    sessionCount--
+  ) {
+    const candidate = generateSchedule(preset, sessionCount, startTime);
+    const totalDuration = candidate.blocks.reduce(
+      (sum, b) => sum + b.durationSeconds,
+      0,
+    );
+    if (totalDuration <= availableSeconds) {
+      base = candidate;
+      break;
+    }
+  }
+
+  if (!base) {
+    return EMPTY_SCHEDULE;
+  }
+
+  // Fill remaining time with a shortened work block
+  const usedSeconds = base.blocks.reduce(
+    (sum, b) => sum + b.durationSeconds,
+    0,
+  );
+  const remaining = availableSeconds - usedSeconds;
+  const lastBlock = base.blocks[base.blocks.length - 1];
+  const workCount = base.blocks.filter((b) => b.phase === "work").length;
+
+  if (lastBlock && remaining > 0 && workCount < preset.maxDailySessions) {
+    const breakDuration = preset.breakMinutes * 60;
+    const extraWorkSeconds = Math.floor(remaining - breakDuration);
+
+    if (extraWorkSeconds >= MIN_EXTRA_WORK_SECONDS) {
+      const cursor =
+        new Date(lastBlock.startTime).getTime() +
+        lastBlock.durationSeconds * 1000;
+
+      base.blocks.push({
+        phase: "break",
+        durationSeconds: breakDuration,
+        baseDurationSeconds: breakDuration,
+        startTime: new Date(cursor).toISOString(),
+        sessionNumber: 0,
+      });
+
+      base.blocks.push({
+        phase: "work",
+        durationSeconds: extraWorkSeconds,
+        baseDurationSeconds: preset.workMinutes * 60,
+        startTime: new Date(cursor + breakDuration * 1000).toISOString(),
+        sessionNumber: workCount + 1,
+      });
+
+      const totals = computeTotals(base.blocks);
+      base.totalWorkMinutes = totals.totalWorkMinutes;
+      base.totalBreakMinutes = totals.totalBreakMinutes;
+      base.breakToWorkRatio = totals.breakToWorkRatio;
+    }
+  }
+
+  return base;
+}
+
+export function suggestBetterPreset(
+  currentPreset: PresetConfig,
+  startTime: Date,
+  endTime: Date,
+): {
+  presetId: PresetId;
+  focusMinutes: number;
+  currentFocusMinutes: number;
+} | null {
+  const currentSchedule = scheduleFromTimeRange(
+    currentPreset,
+    startTime,
+    endTime,
+  );
+  const currentFocus = currentSchedule.totalWorkMinutes;
+
+  let best: { presetId: PresetId; focusMinutes: number } | null = null;
+
+  for (const [id, preset] of Object.entries(PRESETS)) {
+    if (id === "custom" || id === currentPreset.id) continue;
+    const schedule = scheduleFromTimeRange(preset, startTime, endTime);
+    // Only consider if the schedule actually fits (has blocks)
+    if (
+      schedule.blocks.length > 0 &&
+      schedule.totalWorkMinutes > (best?.focusMinutes ?? currentFocus)
+    ) {
+      best = {
+        presetId: id as PresetId,
+        focusMinutes: schedule.totalWorkMinutes,
+      };
+    }
+  }
+
+  if (!best) return null;
+
+  // When current preset doesn't fit at all, always suggest
+  if (currentFocus === 0) {
+    return { ...best, currentFocusMinutes: 0 };
+  }
+
+  // Only suggest if improvement is significant
+  const improvement = (best.focusMinutes - currentFocus) / currentFocus;
+  if (improvement < SUGGESTION_MIN_IMPROVEMENT) return null;
+
+  return { ...best, currentFocusMinutes: currentFocus };
+}
+
+export function validateBreakRatio(schedule: Schedule): {
+  valid: boolean;
+  suggestion: string;
+} {
+  const { breakToWorkRatio } = schedule;
+  if (
+    breakToWorkRatio >= TARGET_BREAK_RATIO_MIN &&
+    breakToWorkRatio <= TARGET_BREAK_RATIO_MAX
+  ) {
+    return { valid: true, suggestion: "ratioGood" };
+  }
+  if (breakToWorkRatio < TARGET_BREAK_RATIO_MIN) {
+    return { valid: false, suggestion: "breaksTooShort" };
+  }
+  return { valid: false, suggestion: "breaksTooLong" };
+}
+
+export function getPeakFocusInfo(currentHour: number): {
+  isPeak: boolean;
+  label: string;
+} {
+  if (currentHour >= 8 && currentHour < 11) {
+    return { isPeak: true, label: "peakFocus" };
+  }
+  if (currentHour >= 14 && currentHour < 16) {
+    return { isPeak: false, label: "afternoonDip" };
+  }
+  return { isPeak: false, label: "" };
+}

--- a/lib/pomodoro/storage.ts
+++ b/lib/pomodoro/storage.ts
@@ -1,0 +1,173 @@
+import { MAX_STATS_DAYS, PRESETS } from "./constants";
+import type {
+  Phase,
+  PresetConfig,
+  PresetId,
+  SessionRecord,
+  StoredTimerData,
+} from "./types";
+
+const TIMER_KEY = "pomodoro:timer";
+const STATS_KEY = "pomodoro:stats";
+
+function isSameDay(isoA: string, isoB: string): boolean {
+  return isoA.slice(0, 10) === isoB.slice(0, 10);
+}
+
+function isValidPresetId(id: unknown): id is PresetId {
+  return (
+    typeof id === "string" &&
+    ["pomodoro", "desktime", "deepwork", "custom"].includes(id)
+  );
+}
+
+function isValidPhase(p: unknown): p is Phase {
+  return typeof p === "string" && ["work", "break", "longBreak"].includes(p);
+}
+
+function isValidPresetConfig(c: unknown): c is PresetConfig {
+  if (typeof c !== "object" || c === null) return false;
+  const obj = c as Record<string, unknown>;
+  return (
+    isValidPresetId(obj.id) &&
+    typeof obj.workMinutes === "number" &&
+    typeof obj.breakMinutes === "number" &&
+    typeof obj.longBreakMinutes === "number" &&
+    typeof obj.sessionsBeforeLongBreak === "number" &&
+    typeof obj.maxDailySessions === "number"
+  );
+}
+
+function isValidStoredTimer(data: unknown): data is StoredTimerData {
+  if (typeof data !== "object" || data === null) return false;
+  const obj = data as Record<string, unknown>;
+
+  if (!isValidPresetId(obj.presetId)) return false;
+  if (!isValidPresetConfig(obj.customConfig)) return false;
+  if (typeof obj.sessionCount !== "number") return false;
+  if (typeof obj.savedAt !== "string") return false;
+
+  const timer = obj.timerState as Record<string, unknown> | undefined;
+  if (typeof timer !== "object" || timer === null) return false;
+  if (!isValidPhase(timer.phase)) return false;
+  if (typeof timer.currentBlockIndex !== "number") return false;
+  if (typeof timer.remainingSeconds !== "number") return false;
+  if (typeof timer.isRunning !== "boolean") return false;
+  if (typeof timer.completedSessions !== "number") return false;
+
+  const schedule = obj.schedule as Record<string, unknown> | undefined;
+  if (typeof schedule !== "object" || schedule === null) return false;
+  if (!Array.isArray(schedule.blocks)) return false;
+
+  return true;
+}
+
+export function loadTimerState(): StoredTimerData | null {
+  try {
+    const raw = localStorage.getItem(TIMER_KEY);
+    if (!raw) return null;
+    const data = JSON.parse(raw);
+    if (!isValidStoredTimer(data)) return null;
+
+    const today = new Date().toISOString();
+    if (!isSameDay(data.savedAt, today)) return null;
+
+    return data;
+  } catch {
+    return null;
+  }
+}
+
+export function saveTimerState(data: StoredTimerData): void {
+  try {
+    localStorage.setItem(TIMER_KEY, JSON.stringify(data));
+  } catch {
+    // localStorage full or unavailable
+  }
+}
+
+export function clearTimerState(): void {
+  try {
+    localStorage.removeItem(TIMER_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+function isValidSessionRecord(r: unknown): r is SessionRecord {
+  if (typeof r !== "object" || r === null) return false;
+  const obj = r as Record<string, unknown>;
+  return (
+    typeof obj.date === "string" &&
+    isValidPresetId(obj.presetId) &&
+    typeof obj.sessionsCompleted === "number" &&
+    typeof obj.totalFocusSeconds === "number" &&
+    typeof obj.totalBreakSeconds === "number"
+  );
+}
+
+export function loadStats(): SessionRecord[] {
+  try {
+    const raw = localStorage.getItem(STATS_KEY);
+    if (!raw) return [];
+    const data = JSON.parse(raw);
+    if (!Array.isArray(data)) return [];
+
+    const valid = data.filter(isValidSessionRecord);
+
+    // Trim to MAX_STATS_DAYS
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - MAX_STATS_DAYS);
+    const cutoffStr = cutoff.toISOString().slice(0, 10);
+    return valid.filter((r) => r.date >= cutoffStr);
+  } catch {
+    return [];
+  }
+}
+
+export function saveStats(records: SessionRecord[]): void {
+  try {
+    localStorage.setItem(STATS_KEY, JSON.stringify(records));
+  } catch {
+    // localStorage full or unavailable
+  }
+}
+
+export function upsertTodayStats(
+  records: SessionRecord[],
+  presetId: PresetId,
+  focusSeconds: number,
+  breakSeconds: number,
+): SessionRecord[] {
+  const today = new Date().toISOString().slice(0, 10);
+  const existing = records.find((r) => r.date === today);
+
+  if (existing) {
+    return records.map((r) =>
+      r.date === today
+        ? {
+            ...r,
+            presetId,
+            sessionsCompleted: r.sessionsCompleted + 1,
+            totalFocusSeconds: r.totalFocusSeconds + focusSeconds,
+            totalBreakSeconds: r.totalBreakSeconds + breakSeconds,
+          }
+        : r,
+    );
+  }
+
+  return [
+    ...records,
+    {
+      date: today,
+      presetId,
+      sessionsCompleted: 1,
+      totalFocusSeconds: focusSeconds,
+      totalBreakSeconds: breakSeconds,
+    },
+  ];
+}
+
+export function getDefaultCustomConfig(): PresetConfig {
+  return { ...PRESETS.custom };
+}

--- a/lib/pomodoro/types.ts
+++ b/lib/pomodoro/types.ts
@@ -1,0 +1,52 @@
+export type PresetId = "pomodoro" | "desktime" | "deepwork" | "custom";
+
+export type PresetConfig = {
+  id: PresetId;
+  workMinutes: number;
+  breakMinutes: number;
+  longBreakMinutes: number;
+  sessionsBeforeLongBreak: number;
+  maxDailySessions: number;
+};
+
+export type Phase = "work" | "break" | "longBreak";
+
+export type ScheduleBlock = {
+  phase: Phase;
+  durationSeconds: number;
+  baseDurationSeconds: number;
+  startTime: string; // ISO string for serialization
+  sessionNumber: number; // 1-indexed for work, 0 for breaks
+};
+
+export type Schedule = {
+  blocks: ScheduleBlock[];
+  totalWorkMinutes: number;
+  totalBreakMinutes: number;
+  breakToWorkRatio: number;
+};
+
+export type TimerState = {
+  phase: Phase;
+  currentBlockIndex: number;
+  remainingSeconds: number;
+  isRunning: boolean;
+  completedSessions: number;
+};
+
+export type SessionRecord = {
+  date: string; // YYYY-MM-DD
+  presetId: PresetId;
+  sessionsCompleted: number;
+  totalFocusSeconds: number;
+  totalBreakSeconds: number;
+};
+
+export type StoredTimerData = {
+  presetId: PresetId;
+  customConfig: PresetConfig;
+  sessionCount: number;
+  schedule: Schedule;
+  timerState: TimerState;
+  savedAt: string; // ISO string
+};

--- a/messages/de.json
+++ b/messages/de.json
@@ -20,7 +20,8 @@
     "menu": "Menü",
     "home": "Startseite",
     "blog": "Blog",
-    "games": "Spiele"
+    "games": "Spiele",
+    "tools": "Werkzeuge"
   },
   "games": {
     "title": "Spiele",
@@ -49,7 +50,7 @@
         "info": "Info",
         "noMatches": "Keine passenden Wörter gefunden",
         "enterGuess": "Gib deinen Versuch ein und markiere jeden Buchstaben",
-        "clickToMark": "Klicke auf Kacheln: absent → present → correct",
+        "clickToMark": "Klicke auf Kacheln: absent \u2192 present \u2192 correct",
         "controls": {
           "play": "Start",
           "pause": "Pause",
@@ -69,6 +70,105 @@
       "description": "Klassisches Würfelspiel für 1-6 Spieler",
       "play": "Spielen",
       "instructions": "Würfle und sammle Punkte mit Kombinationen. Spiele digital oder nutze es als Tracker für echte Würfel."
+    }
+  },
+  "tools": {
+    "title": "Werkzeuge",
+    "subtitle": "Produktivitätstools auf wissenschaftlicher Grundlage.",
+    "pomodoro": {
+      "title": "Pomodoro-Timer",
+      "description": "Fokus-Timer mit wissenschaftlich fundierten Arbeits- und Pausenintervallen.",
+      "open": "Timer öffnen"
+    }
+  },
+  "pomodoro": {
+    "title": "Pomodoro-Timer",
+    "instructions": "Wähle ein Preset, dann lege die Anzahl der Sessions fest oder wähle eine Uhrzeit bis zu der du fokussieren möchtest.",
+    "presets": {
+      "pomodoro": "Pomodoro Klassisch",
+      "pomodoroDesc": "25 Min Arbeit / 5 Min Pause",
+      "desktime": "DeskTime",
+      "desktimeDesc": "52 Min Arbeit / 17 Min Pause",
+      "deepwork": "Deep Work",
+      "deepworkDesc": "90 Min Arbeit / 20 Min Pause",
+      "custom": "Benutzerdefiniert",
+      "customDesc": "Eigene Zeiten festlegen"
+    },
+    "timer": {
+      "work": "Fokus",
+      "break": "Pause",
+      "longBreak": "Lange Pause",
+      "start": "Starten",
+      "pause": "Pausieren",
+      "resume": "Fortsetzen",
+      "reset": "Zurücksetzen",
+      "skip": "Überspringen",
+      "done": "Alle Sessions abgeschlossen!"
+    },
+    "schedule": {
+      "title": "Zeitplan",
+      "session": "Session {number}",
+      "breakLabel": "Pause",
+      "longBreakLabel": "Lange Pause",
+      "duration": "{minutes} Min",
+      "totalWork": "Fokus gesamt: {minutes} Min",
+      "totalBreak": "Pausen gesamt: {minutes} Min",
+      "ratio": "Pausenanteil: {percent}%",
+      "ratioGood": "Im empfohlenen Bereich von 20\u201325%.",
+      "breaksTooShort": "Pausen sind kürzer als empfohlen. Längere Pausen in Betracht ziehen.",
+      "breaksTooLong": "Pausen übersteigen den empfohlenen Anteil. Kürzere Pausen in Betracht ziehen."
+    },
+    "sessions": {
+      "label": "Sessions",
+      "completed": "{current} von {total} abgeschlossen"
+    },
+    "focusUntil": {
+      "label": "Fokus bis",
+      "endTime": "Endzeit",
+      "pastTime": "Endzeit muss in der Zukunft liegen",
+      "noFit": "Gewähltes Preset passt nicht in dieses Zeitfenster",
+      "suggestion": "{preset} passt besser: {minutes} Min Fokus",
+      "switch": "Wechseln"
+    },
+    "custom": {
+      "workMinutes": "Arbeit (Min)",
+      "breakMinutes": "Pause (Min)",
+      "longBreakMinutes": "Lange Pause (Min)",
+      "sessionsBeforeLongBreak": "Sessions vor langer Pause",
+      "sessionCount": "Anzahl Sessions"
+    },
+    "stats": {
+      "title": "Statistik",
+      "today": "Heute",
+      "sessionsToday": "{count} Sessions",
+      "focusToday": "{minutes} Min Fokus",
+      "streak": "{days}-Tage-Serie",
+      "allTime": "Gesamt: {sessions} Sessions, {hours}h Fokus",
+      "noData": "Noch keine Sessions aufgezeichnet."
+    },
+    "timeOfDay": {
+      "peakFocus": "Optimales Fokus-Fenster \u2014 beste Zeit für konzentrierte Arbeit.",
+      "afternoonDip": "Nachmittagstief \u2014 leichtere Aufgabe oder kürzere Session erwägen."
+    },
+    "notifications": {
+      "workDone": "Fokus-Session abgeschlossen! Zeit für eine Pause.",
+      "breakDone": "Pause vorbei. Bereit für die nächste Session?",
+      "allDone": "Alle Sessions abgeschlossen! Gute Arbeit heute."
+    },
+    "sources": {
+      "title": "Wissenschaftliche Quellen",
+      "pomodoroTechnique": "Die Pomodoro-Technik (Cirillo, 2006)",
+      "pomodoroDesc": "Ursprüngliches 25/5-Muster mit 4-Zyklen-Struktur. Grundlage für strukturiertes Intervall-Fokussieren.",
+      "desktime": "DeskTime-Produktivitätsstudie (Draugiem Group, 2014)",
+      "desktimeDesc": "Analyse der produktivsten 10% der Mitarbeiter ergab ein 52/17 Arbeits-Pausen-Verhältnis.",
+      "ultradian": "Grundlegender Ruhe-Aktivitäts-Zyklus (Kleitman, 1982)",
+      "ultradianDesc": "90\u2013120-minütiger biologischer Rhythmus, der Wachheit und kognitive Leistung beeinflusst.",
+      "huberman": "Huberman Lab: Fokus- & Konzentrationsprotokolle",
+      "hubermanDesc": "Neurobiologische Grundlage für 90-Minuten-Fokussessions. Maximal 2\u20133 Sessions pro Tag.",
+      "microbreaks": "Mikropausen-Metaanalyse (Albulescu et al., 2022)",
+      "microbreaksDesc": "Systematische Übersicht zeigt, dass längere Pausen eine bessere Leistungserholung bewirken.",
+      "breakRatio": "Optimale Arbeits-Pausen-Verhältnisse (Bailey, 2017)",
+      "breakRatioDesc": "Die produktivsten Menschen verbringen 20\u201325% ihres Arbeitstages mit Pausen."
     }
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -20,7 +20,8 @@
     "menu": "Menu",
     "home": "Home",
     "blog": "Blog",
-    "games": "Games"
+    "games": "Games",
+    "tools": "Tools"
   },
   "games": {
     "title": "Games",
@@ -49,7 +50,7 @@
         "info": "Info",
         "noMatches": "No matching words found",
         "enterGuess": "Enter your guess and mark each letter",
-        "clickToMark": "Click tiles to cycle: absent → present → correct",
+        "clickToMark": "Click tiles to cycle: absent \u2192 present \u2192 correct",
         "controls": {
           "play": "Play",
           "pause": "Pause",
@@ -69,6 +70,105 @@
       "description": "Classic dice game for 1-6 players",
       "play": "Play",
       "instructions": "Roll dice and score combinations. Play digitally or use as a tracker for physical dice."
+    }
+  },
+  "tools": {
+    "title": "Tools",
+    "subtitle": "Productivity tools grounded in science.",
+    "pomodoro": {
+      "title": "Pomodoro Timer",
+      "description": "Focus timer with scientifically-backed work/break intervals.",
+      "open": "Open Timer"
+    }
+  },
+  "pomodoro": {
+    "title": "Pomodoro Timer",
+    "instructions": "Choose a preset, then set a number of sessions or pick a time to focus until.",
+    "presets": {
+      "pomodoro": "Pomodoro Classic",
+      "pomodoroDesc": "25 min work / 5 min break",
+      "desktime": "DeskTime",
+      "desktimeDesc": "52 min work / 17 min break",
+      "deepwork": "Deep Work",
+      "deepworkDesc": "90 min work / 20 min break",
+      "custom": "Custom",
+      "customDesc": "Set your own durations"
+    },
+    "timer": {
+      "work": "Focus",
+      "break": "Break",
+      "longBreak": "Long Break",
+      "start": "Start",
+      "pause": "Pause",
+      "resume": "Resume",
+      "reset": "Reset",
+      "skip": "Skip",
+      "done": "All sessions complete!"
+    },
+    "schedule": {
+      "title": "Schedule",
+      "session": "Session {number}",
+      "breakLabel": "Break",
+      "longBreakLabel": "Long Break",
+      "duration": "{minutes} min",
+      "totalWork": "Total focus: {minutes} min",
+      "totalBreak": "Total break: {minutes} min",
+      "ratio": "Break ratio: {percent}%",
+      "ratioGood": "Within the recommended 20\u201325% range.",
+      "breaksTooShort": "Breaks are shorter than recommended. Consider longer breaks.",
+      "breaksTooLong": "Breaks exceed the recommended ratio. Consider shorter breaks."
+    },
+    "sessions": {
+      "label": "Sessions",
+      "completed": "{current} of {total} completed"
+    },
+    "focusUntil": {
+      "label": "Focus until",
+      "endTime": "End time",
+      "pastTime": "End time must be in the future",
+      "noFit": "Selected preset doesn't fit in this time window",
+      "suggestion": "{preset} fits better: {minutes} min focus",
+      "switch": "Switch"
+    },
+    "custom": {
+      "workMinutes": "Work (min)",
+      "breakMinutes": "Break (min)",
+      "longBreakMinutes": "Long break (min)",
+      "sessionsBeforeLongBreak": "Sessions before long break",
+      "sessionCount": "Number of sessions"
+    },
+    "stats": {
+      "title": "Statistics",
+      "today": "Today",
+      "sessionsToday": "{count} sessions",
+      "focusToday": "{minutes} min focus",
+      "streak": "{days}-day streak",
+      "allTime": "All time: {sessions} sessions, {hours}h focus",
+      "noData": "No sessions recorded yet."
+    },
+    "timeOfDay": {
+      "peakFocus": "Peak focus window \u2014 your best time for deep work.",
+      "afternoonDip": "Afternoon dip \u2014 consider a lighter task or shorter session."
+    },
+    "notifications": {
+      "workDone": "Focus session complete! Time for a break.",
+      "breakDone": "Break is over. Ready for the next session?",
+      "allDone": "All sessions complete! Great work today."
+    },
+    "sources": {
+      "title": "Scientific References",
+      "pomodoroTechnique": "The Pomodoro Technique (Cirillo, 2006)",
+      "pomodoroDesc": "Original 25/5 pattern with 4-cycle structure. Foundation of structured interval-based focus.",
+      "desktime": "DeskTime Productivity Study (Draugiem Group, 2014)",
+      "desktimeDesc": "Analysis of top 10% most productive workers found 52/17 work-break ratio. Updated data suggests 75\u2013112 min sessions.",
+      "ultradian": "Basic Rest-Activity Cycle (Kleitman, 1982)",
+      "ultradianDesc": "90\u2013120 minute biological rhythm affecting alertness and cognitive performance during wakefulness.",
+      "huberman": "Huberman Lab: Focus & Concentration Protocols",
+      "hubermanDesc": "Neurobiological basis for 90-minute focus sessions with 10\u201330 min defocus periods. Max 2\u20133 sessions per day.",
+      "microbreaks": "Micro-Breaks Meta-Analysis (Albulescu et al., 2022)",
+      "microbreaksDesc": "Systematic review showing longer breaks yield greater performance recovery, especially after depleting tasks.",
+      "breakRatio": "Optimal Work-Break Ratios (Bailey, 2017)",
+      "breakRatioDesc": "Most productive people spend 20\u201325% of their workday on breaks. Break quality matters as much as duration."
     }
   }
 }


### PR DESCRIPTION
## Summary

- Adds a Pomodoro focus timer at `/tools/pomodoro` with three science-backed presets (Pomodoro 25/5, DeskTime 52/17, Deep Work 90/20) plus custom durations
- Adaptive fatigue model increases break duration 12% per cycle (capped at 1.5×), targeting a 20–25% break ratio
- **Focus Until mode**: set an end time and the system auto-schedules optimal work/break blocks within that window, filling remaining time with shortened sessions
- **Smart preset suggestion**: when another preset would give ≥15% more focus time, a suggestion banner offers a one-click switch
- Collapsible scientific references section linking to Cirillo, DeskTime, Kleitman BRAC, Huberman Lab, micro-breaks meta-analysis, and Bailey
- Browser notifications for session transitions, localStorage persistence with drift compensation, time-of-day awareness hints
- Full i18n support (EN/DE), dark/light theme compatible
- 41 unit tests covering scheduler, fill logic, preset suggestions, break ratio validation, and peak focus detection

## Test plan

- [ ] Navigate to `/en/tools/pomodoro` and `/de/tools/pomodoro` — verify translations
- [ ] Select each preset, start timer, verify countdown and auto-advance between work/break
- [ ] Test "Focus Until" mode: set a future time, verify schedule fills the window
- [ ] Test past time rejection: select a past time, verify error message appears
- [ ] Test preset suggestion: select Deep Work with a short window, verify suggestion banner appears
- [ ] Close and reopen tab — verify timer state restores from localStorage
- [ ] Complete a session, check stats panel updates
- [ ] Toggle dark/light theme, verify colors
- [ ] Verify sources section expands with clickable links
- [ ] `bunx vitest run lib/pomodoro/__tests__/scheduler.test.ts` — 41 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)