### PR TITLE
refactor: resolve all Phase 1 technical debt

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -61,7 +61,8 @@
       "Bash(wc:*)",
       "Bash(jj git init:*)",
       "Bash(jj file show:*)",
-      "Bash(bunx vitest run:*)"
+      "Bash(bunx vitest run:*)",
+      "Bash(bun install:*)"
     ]
   },
   "outputStyle": "default"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,8 @@ jobs:
       - name: Run Biome checks
         run: bun run check
 
+      - name: Run tests
+        run: bun run test
+
       - name: Build the project
         run: bun run build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,30 +88,57 @@ jj bookmark create feature/other
 
 **Commit format:** `type: description` (feat, fix, chore, docs, refactor, test, perf)
 
+## ADR-First Development Workflow
+
+All architectural decisions are documented in `docs/adr/`. The ADRs are the source of truth.
+
+**Before implementing any new feature, structural change, or pattern deviation:**
+
+1. **Check ADRs** — Read relevant ADRs in `docs/adr/` to understand existing decisions
+2. **Update/Create ADR** — If the change contradicts an existing ADR, update it first (set old to "Superseded"). If the change introduces a new pattern, create a new ADR (status "Proposed")
+3. **Update Implementation Plan** — Reflect the change in `docs/IMPLEMENTATION_PLAN.md`
+4. **Implement** — Follow the ADR and implementation plan
+5. **Verify compliance** — Use the checklist at the bottom of `docs/IMPLEMENTATION_PLAN.md`
+
+**Nothing gets implemented without being documented in an ADR first.**
+
+Key ADR documents:
+- `docs/adr/README.md` — Index, governance, known inconsistencies
+- `docs/IMPLEMENTATION_PLAN.md` — Phased plan derived from ADRs
+
 ## Architecture
 
 **Stack:** Next.js 16 (App Router) + React 19 + Tailwind 4 + Biome + bun
 
-**Typography:** Custom MDX components in `mdx-components.tsx`
-- Style MDX elements (h1, p, etc.) with Tailwind classes directly
-- No @tailwindcss/typography (incompatible with Tailwind v4)
+**Feature architecture** (ADR-005): Four layers for every interactive feature:
+1. `lib/{feature}/` — Pure logic, types, constants (no React)
+2. `components/{feature}/use-{feature}.ts` — Custom hook (React bridge)
+3. `components/{feature}/*.tsx` — UI components ("use client")
+4. `app/[locale]/{category}/{feature}/page.tsx` — Server component route
 
-**Internationalization:** next-intl with locale-based routing
+**Internationalization** (ADR-003): next-intl with locale-based routing
 - Locales: `en`, `de` (configured in `i18n/config.ts`)
 - Routes use `[locale]` dynamic segment: `app/[locale]/page.tsx`
-- Translations: `messages/{locale}.json`
-- Middleware handles locale detection and redirects
+- Translations: `messages/{locale}.json` — all UI text via `useTranslations()`
+- Key naming: camelCase, namespaced by feature
 
-**Theming:** next-themes with CSS variables
-- Theme tokens in `app/globals.css` (light/dark using oklch colors)
+**Styling** (ADR-002): Tailwind 4 CSS-first + next-themes
+- Theme tokens in `app/globals.css` (oklch colors, `@theme inline` block)
+- No JS config file — pure CSS configuration
 - `ThemeProvider` wraps app in locale layout
 
-**UI Components:** shadcn/ui pattern
-- Base components in `components/ui/` (e.g., `Button` with CVA variants)
+**UI Components** (ADR-004): shadcn/ui pattern
+- Base components in `components/ui/` (Button with CVA variants, DropdownMenu)
 - Utility: `cn()` from `@/lib/utils` for class merging
 
+**State management** (ADR-012): useState + useEffect + localStorage
+- Per-feature isolation, no global state
+- Runtime type guards for storage validation (follow Pomodoro's pattern)
+
+**Testing** (ADR-007): Vitest, pure function tests in `lib/{feature}/__tests__/`
+
 **Key files:**
-- `middleware.ts` — Locale routing middleware
+- `proxy.ts` — Locale routing middleware (Next.js 16 pattern)
 - `app/layout.tsx` — Root layout (imports globals.css)
 - `app/[locale]/layout.tsx` — Locale layout (providers, html lang)
 - `i18n/request.ts` — next-intl request config
@@ -120,14 +147,18 @@ jj bookmark create feature/other
 
 **Implemented:**
 - Personal blog (MDX) at `/blog`
-- Wordle game at `/games/wordle` (EN/DE word lists)
+- Wordle game at `/games/wordle` (EN/DE word lists, solver, demo)
+- Kniffel tracker at `/games/kniffel` (digital + manual modes)
+- Pomodoro timer at `/tools/pomodoro` (presets, scheduling, stats)
 
-**Planned:**
-- Song bingo game (Spotify OAuth)
-- Kniffel tracker
+**Planned** (see `docs/IMPLEMENTATION_PLAN.md`):
+- Song bingo game (Spotify OAuth — needs ADR-013)
+- Blog enhancements (syntax highlighting, more MDX components)
 
 ## Infrastructure
 
-- Hosting: Hetzner via Docker
-- Reverse proxy: Caddy (handles HTTPS)
+- Hosting: Hetzner via Docker (ADR-009)
+- Reverse proxy: Caddy (handles HTTPS + compression)
 - Output: standalone (`next.config.ts`)
+- CI: GitHub Actions (lint + build on PRs, manual/release deploys)
+- VCS: Jujutsu (ADR-010)

--- a/app/[locale]/blog/[slug]/page.tsx
+++ b/app/[locale]/blog/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { getTranslations } from "next-intl/server";
 import { MDXRemote } from "next-mdx-remote/rsc";
 import { locales } from "@/i18n/config";
 import { getPostBySlug, getPostSlugs } from "@/lib/posts";
@@ -22,6 +23,7 @@ export default async function BlogPost({
 }) {
   const { locale, slug } = await params;
   const post = await getPostBySlug(locale, slug);
+  const t = await getTranslations("nav");
 
   if (!post) notFound();
 
@@ -31,7 +33,7 @@ export default async function BlogPost({
         href={`/${locale}/blog`}
         className="text-sm text-muted-foreground hover:text-foreground mb-1 inline-block"
       >
-        ← go back
+        &larr; {t("back")}
       </Link>
       <h1 className="text-3xl font-bold">{post.meta.title}</h1>
       <p className="text-sm text-muted-foreground mt-2 mb-8">

--- a/app/[locale]/games/kniffel/page.tsx
+++ b/app/[locale]/games/kniffel/page.tsx
@@ -9,6 +9,7 @@ interface KniffelPageProps {
 export default async function KniffelPage({ params }: KniffelPageProps) {
   const { locale } = await params;
   const t = await getTranslations("games");
+  const nav = await getTranslations("nav");
 
   return (
     <div className="flex flex-col items-center space-y-6">
@@ -17,7 +18,7 @@ export default async function KniffelPage({ params }: KniffelPageProps) {
           href={`/${locale}/games`}
           className="text-sm text-muted-foreground hover:text-foreground"
         >
-          ← {locale === "de" ? "zurück" : "back"}
+          &larr; {nav("back")}
         </Link>
       </div>
       <h1 className="text-2xl font-bold">{t("kniffel.title")}</h1>

--- a/app/[locale]/games/wordle/demo/page.tsx
+++ b/app/[locale]/games/wordle/demo/page.tsx
@@ -10,6 +10,7 @@ interface SolverDemoPageProps {
 export default async function SolverDemoPage({ params }: SolverDemoPageProps) {
   const { locale } = await params;
   const t = await getTranslations("games");
+  const nav = await getTranslations("nav");
   const wordList = locale === "de" ? WORDS_DE : WORDS_EN;
 
   return (
@@ -19,14 +20,14 @@ export default async function SolverDemoPage({ params }: SolverDemoPageProps) {
           href={`/${locale}/games/wordle`}
           className="text-sm text-muted-foreground hover:text-foreground"
         >
-          ← {locale === "de" ? "zurück" : "back"}
+          &larr; {nav("back")}
         </Link>
       </div>
       <h1 className="text-2xl font-bold">{t("wordle.solver.demo.title")}</h1>
       <p className="text-muted-foreground text-center max-w-md">
         {t("wordle.solver.demo.description")}
       </p>
-      <SolverDemo wordList={wordList} locale={locale} />
+      <SolverDemo wordList={wordList} />
     </div>
   );
 }

--- a/app/[locale]/games/wordle/page.tsx
+++ b/app/[locale]/games/wordle/page.tsx
@@ -9,6 +9,7 @@ interface WordlePageProps {
 export default async function WordlePage({ params }: WordlePageProps) {
   const { locale } = await params;
   const t = await getTranslations("games");
+  const nav = await getTranslations("nav");
 
   return (
     <div className="flex flex-col items-center space-y-6">
@@ -17,14 +18,14 @@ export default async function WordlePage({ params }: WordlePageProps) {
           href={`/${locale}/games`}
           className="text-sm text-muted-foreground hover:text-foreground"
         >
-          ← {locale === "de" ? "zurück" : "back"}
+          &larr; {nav("back")}
         </Link>
       </div>
       <h1 className="text-2xl font-bold">{t("wordle.title")}</h1>
       <p className="text-muted-foreground text-center max-w-md">
         {t("wordle.instructions")}
       </p>
-      <WordleGame locale={locale} />
+      <WordleGame />
     </div>
   );
 }

--- a/app/[locale]/games/wordle/solver/page.tsx
+++ b/app/[locale]/games/wordle/solver/page.tsx
@@ -2,7 +2,7 @@
 
 import { Keyboard, RotateCcw } from "lucide-react";
 import Link from "next/link";
-import { useParams } from "next/navigation";
+import { useLocale, useTranslations } from "next-intl";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
@@ -19,10 +19,12 @@ import {
 } from "@/lib/wordle/solver";
 
 export default function SolverPage() {
-  const params = useParams();
-  const locale = (params.locale as string) || "en";
+  const locale = useLocale();
+  const t = useTranslations("games.wordle");
+  const ts = useTranslations("games.wordle.solver");
+  const nav = useTranslations("nav");
+
   const wordList = locale === "de" ? WORDS_DE : WORDS_EN;
-  const isDE = locale === "de";
   const inputRef = useRef<HTMLInputElement>(null);
 
   const [showKeyboard, setShowKeyboard] = useState(() => {
@@ -96,16 +98,12 @@ export default function SolverPage() {
           href={`/${locale}/games/wordle`}
           className="text-sm text-muted-foreground hover:text-foreground"
         >
-          ← {isDE ? "zurück" : "back"}
+          &larr; {nav("back")}
         </Link>
       </div>
-      <h1 className="text-2xl font-bold">
-        {isDE ? "Wordle Solver" : "Wordle Solver"}
-      </h1>
+      <h1 className="text-2xl font-bold">{ts("title")}</h1>
       <p className="text-muted-foreground text-center max-w-md">
-        {isDE
-          ? "Hilfe beim Lösen von Wordle-Rätseln. Gib deine Versuche ein und erhalte Vorschläge."
-          : "Get help solving any Wordle puzzle. Enter your guesses and get suggestions."}
+        {ts("description")}
       </p>
 
       {/* Hidden input for mobile keyboard */}
@@ -139,21 +137,20 @@ export default function SolverPage() {
               onLetterInput={handleLetterInput}
               onBackspace={handleBackspace}
               onSubmit={handleSubmit}
-              locale={locale}
             />
           </button>
 
           <div className="flex gap-2">
             <Button onClick={reset} variant="outline" className="gap-2">
               <RotateCcw className="size-4" />
-              {isDE ? "Zurücksetzen" : "Reset"}
+              {t("reset")}
             </Button>
 
             <Button
               variant={showKeyboard ? "secondary" : "ghost"}
               size="icon"
               onClick={() => setShowKeyboard(!showKeyboard)}
-              aria-label={showKeyboard ? "Hide keyboard" : "Show keyboard"}
+              aria-label={showKeyboard ? t("hideKeyboard") : t("showKeyboard")}
             >
               <Keyboard className="size-4" />
             </Button>
@@ -166,7 +163,6 @@ export default function SolverPage() {
               onKey={handleLetterInput}
               onEnter={handleSubmit}
               onBackspace={handleBackspace}
-              locale={locale}
             />
           )}
         </div>
@@ -177,7 +173,6 @@ export default function SolverPage() {
             <SolverSuggestions
               suggestions={suggestions}
               possibleWordsCount={possibleWordsCount}
-              locale={locale}
             />
           </div>
         )}

--- a/app/[locale]/tools/pomodoro/page.tsx
+++ b/app/[locale]/tools/pomodoro/page.tsx
@@ -1,11 +1,26 @@
+import Link from "next/link";
 import { getTranslations } from "next-intl/server";
-import { PomodoroApp } from "@/components/pomodoro/pomodoro-app";
+import { PomodoroApp } from "@/components/pomodoro";
 
-export default async function PomodoroPage() {
+interface PomodoroPageProps {
+  params: Promise<{ locale: string }>;
+}
+
+export default async function PomodoroPage({ params }: PomodoroPageProps) {
+  const { locale } = await params;
   const t = await getTranslations("pomodoro");
+  const nav = await getTranslations("nav");
 
   return (
     <div className="space-y-6">
+      <div>
+        <Link
+          href={`/${locale}/tools`}
+          className="text-sm text-muted-foreground hover:text-foreground"
+        >
+          &larr; {nav("back")}
+        </Link>
+      </div>
       <div className="space-y-2">
         <h1 className="text-3xl font-bold">{t("title")}</h1>
         <p className="text-muted-foreground">{t("instructions")}</p>

--- a/bun.lock
+++ b/bun.lock
@@ -28,12 +28,9 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.3.13",
-        "@testing-library/dom": "^10.4.1",
-        "@testing-library/react": "^16.3.2",
         "@types/bun": "latest",
         "@types/node": "^25.1.0",
         "@types/react": "^19.2.10",
-        "jsdom": "^28.0.0",
         "tw-animate-css": "^1.4.0",
         "vitest": "^4.0.18",
       },
@@ -56,8 +53,6 @@
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
-
-    "@babel/runtime": ["@babel/runtime@7.28.6", "", {}, "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA=="],
 
     "@biomejs/biome": ["@biomejs/biome@2.3.13", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.3.13", "@biomejs/cli-darwin-x64": "2.3.13", "@biomejs/cli-linux-arm64": "2.3.13", "@biomejs/cli-linux-arm64-musl": "2.3.13", "@biomejs/cli-linux-x64": "2.3.13", "@biomejs/cli-linux-x64-musl": "2.3.13", "@biomejs/cli-win32-arm64": "2.3.13", "@biomejs/cli-win32-x64": "2.3.13" }, "bin": { "biome": "bin/biome" } }, "sha512-Fw7UsV0UAtWIBIm0M7g5CRerpu1eKyKAXIazzxhbXYUyMkwNrkX/KLkGI7b+uVDQ5cLUMfOC9vR60q9IDYDstA=="],
 
@@ -443,12 +438,6 @@
 
     "@tailwindcss/typography": ["@tailwindcss/typography@0.5.19", "", { "dependencies": { "postcss-selector-parser": "6.0.10" }, "peerDependencies": { "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1" } }, "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg=="],
 
-    "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
-
-    "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
-
-    "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
-
     "@types/bun": ["@types/bun@1.3.8", "", { "dependencies": { "bun-types": "1.3.8" } }, "sha512-3LvWJ2q5GerAXYxO2mffLTqOzEu5qnhEAlh48Vnu8WQfnmSwbgagjGZV6BoHKJztENYEDn6QmVd949W4uESRJA=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
@@ -497,15 +486,9 @@
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
-    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
-    "ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
-
     "argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
-
-    "aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
@@ -566,8 +549,6 @@
     "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
-
-    "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.18.4", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.2.0" } }, "sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q=="],
 
@@ -689,8 +670,6 @@
 
     "lucide-react": ["lucide-react@0.563.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-8dXPB2GI4dI8jV4MgUDGBeLdGk8ekfqVZ0BdLcrRzocGgG75ltNEmWS+gE7uokKF/0oSUuczNDT+g9hFJ23FkA=="],
 
-    "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
-
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "markdown-extensions": ["markdown-extensions@2.0.0", "", {}, "sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q=="],
@@ -807,8 +786,6 @@
 
     "postcss-selector-parser": ["postcss-selector-parser@6.0.10", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w=="],
 
-    "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
-
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
@@ -816,8 +793,6 @@
     "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
 
     "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
-
-    "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
     "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
 

--- a/components/kniffel/use-kniffel.ts
+++ b/components/kniffel/use-kniffel.ts
@@ -4,20 +4,20 @@ import { useCallback, useEffect, useState } from "react";
 import {
   ALL_CATEGORIES,
   calculateScore,
+  clearGameState,
   createInitialDice,
   type GameMode,
   type GameState,
   isPlayerComplete,
+  loadGameState,
   MAX_ROLLS,
   type Player,
   resetHolds,
   rollDice,
   type ScoreCategory,
-  type StoredGameState,
+  saveGameState,
   toggleHold,
 } from "@/lib/kniffel";
-
-const STORAGE_KEY = "kniffel-state";
 
 function createEmptyScores(): Record<ScoreCategory, number | null> {
   return Object.fromEntries(ALL_CATEGORIES.map((cat) => [cat, null])) as Record<
@@ -47,50 +47,6 @@ function createInitialState(): GameState {
   };
 }
 
-function loadGameState(): StoredGameState | null {
-  if (typeof window === "undefined") return null;
-  try {
-    const stored = localStorage.getItem(STORAGE_KEY);
-    if (!stored) return null;
-    return JSON.parse(stored) as StoredGameState;
-  } catch {
-    return null;
-  }
-}
-
-function saveGameState(state: GameState): void {
-  if (typeof window === "undefined") return;
-  if (state.phase === "mode-select" || !state.mode) {
-    clearGameState();
-    return;
-  }
-  try {
-    const toStore: StoredGameState = {
-      mode: state.mode,
-      phase: state.phase,
-      players: state.players,
-      currentPlayerIndex: state.currentPlayerIndex,
-      currentTurn: state.currentTurn,
-      dice: state.dice,
-      rollsRemaining: state.rollsRemaining,
-      hasRolled: state.hasRolled,
-      timestamp: Date.now(),
-    };
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(toStore));
-  } catch {
-    // Ignore storage errors
-  }
-}
-
-function clearGameState(): void {
-  if (typeof window === "undefined") return;
-  try {
-    localStorage.removeItem(STORAGE_KEY);
-  } catch {
-    // Ignore storage errors
-  }
-}
-
 export function useKniffel() {
   const [gameState, setGameState] = useState<GameState>(() => {
     const stored = loadGameState();
@@ -118,7 +74,21 @@ export function useKniffel() {
 
   // Save state on changes
   useEffect(() => {
-    saveGameState(gameState);
+    if (gameState.phase === "mode-select" || !gameState.mode) {
+      clearGameState();
+      return;
+    }
+    saveGameState({
+      mode: gameState.mode,
+      phase: gameState.phase,
+      players: gameState.players,
+      currentPlayerIndex: gameState.currentPlayerIndex,
+      currentTurn: gameState.currentTurn,
+      dice: gameState.dice,
+      rollsRemaining: gameState.rollsRemaining,
+      hasRolled: gameState.hasRolled,
+      timestamp: Date.now(),
+    });
   }, [gameState]);
 
   const selectMode = useCallback((mode: GameMode) => {

--- a/components/pomodoro/index.ts
+++ b/components/pomodoro/index.ts
@@ -1,0 +1,1 @@
+export { PomodoroApp } from "./pomodoro-app";

--- a/components/pomodoro/pomodoro-app.tsx
+++ b/components/pomodoro/pomodoro-app.tsx
@@ -1,35 +1,7 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
-import { PRESETS } from "@/lib/pomodoro/constants";
-import {
-  requestPermission,
-  sendNotification,
-} from "@/lib/pomodoro/notifications";
-import {
-  generateSchedule,
-  getPeakFocusInfo,
-  scheduleFromTimeRange,
-  suggestBetterPreset,
-} from "@/lib/pomodoro/scheduler";
-import {
-  clearTimerState,
-  getDefaultCustomConfig,
-  loadStats,
-  loadTimerState,
-  saveStats,
-  saveTimerState,
-  upsertTodayStats,
-} from "@/lib/pomodoro/storage";
-import type {
-  PresetConfig,
-  PresetId,
-  Schedule,
-  SessionRecord,
-  TimerState,
-} from "@/lib/pomodoro/types";
 import { CustomPresetForm } from "./custom-preset-form";
 import { PresetSelector } from "./preset-selector";
 import { ScheduleView } from "./schedule-view";
@@ -37,359 +9,51 @@ import { SessionTrack } from "./session-track";
 import { SourcesSection } from "./sources-section";
 import { StatsPanel } from "./stats-panel";
 import { TimerDisplay } from "./timer-display";
-
-type SchedulingMode = "sessions" | "focusUntil";
-
-const DEFAULT_SESSION_COUNT = 4;
-
-function getDefaultEndTime(): string {
-  const d = new Date();
-  d.setHours(d.getHours() + 2, 0, 0, 0);
-  return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
-}
-
-function getActivePreset(
-  presetId: PresetId,
-  customConfig: PresetConfig,
-): PresetConfig {
-  return presetId === "custom" ? customConfig : PRESETS[presetId];
-}
+import { usePomodoro } from "./use-pomodoro";
 
 export function PomodoroApp() {
-  const tNotif = useTranslations("pomodoro.notifications");
   const tTimer = useTranslations("pomodoro.timer");
   const tSessions = useTranslations("pomodoro.sessions");
   const tTimeOfDay = useTranslations("pomodoro.timeOfDay");
   const tFocusUntil = useTranslations("pomodoro.focusUntil");
   const tPresets = useTranslations("pomodoro.presets");
 
-  // Error state
-  const [endTimeError, setEndTimeError] = useState<string | null>(null);
-
-  // Config state
-  const [presetId, setPresetId] = useState<PresetId>("pomodoro");
-  const [customConfig, setCustomConfig] = useState<PresetConfig>(
-    getDefaultCustomConfig(),
-  );
-  const [sessionCount, setSessionCount] = useState(DEFAULT_SESSION_COUNT);
-  const [schedulingMode, setSchedulingMode] =
-    useState<SchedulingMode>("sessions");
-  const [endTimeStr, setEndTimeStr] = useState(getDefaultEndTime);
-
-  // Schedule & timer
-  const [schedule, setSchedule] = useState<Schedule | null>(null);
-  const [timerState, setTimerState] = useState<TimerState>({
-    phase: "work",
-    currentBlockIndex: 0,
-    remainingSeconds: 0,
-    isRunning: false,
-    completedSessions: 0,
-  });
-
-  // Stats
-  const [stats, setStats] = useState<SessionRecord[]>([]);
-  const [loaded, setLoaded] = useState(false);
-
-  // Track last completed work block for stats
-  const lastWorkDurationRef = useRef(0);
-
-  // Load from localStorage on mount
-  useEffect(() => {
-    const stored = loadTimerState();
-    if (stored) {
-      setPresetId(stored.presetId);
-      setCustomConfig(stored.customConfig);
-      setSessionCount(stored.sessionCount);
-      setSchedule(stored.schedule);
-
-      // Handle time drift if timer was running
-      let restoredTimer = stored.timerState;
-      if (restoredTimer.isRunning) {
-        const elapsed = Math.floor(
-          (Date.now() - new Date(stored.savedAt).getTime()) / 1000,
-        );
-        restoredTimer = {
-          ...restoredTimer,
-          remainingSeconds: Math.max(
-            0,
-            restoredTimer.remainingSeconds - elapsed,
-          ),
-          isRunning: false, // Pause on restore, let user decide
-        };
-      }
-      setTimerState(restoredTimer);
-    }
-
-    setStats(loadStats());
-    setLoaded(true);
-  }, []);
-
-  // Save timer state on changes
-  useEffect(() => {
-    if (!loaded || !schedule) return;
-    saveTimerState({
-      presetId,
-      customConfig,
-      sessionCount,
-      schedule,
-      timerState,
-      savedAt: new Date().toISOString(),
-    });
-  }, [loaded, presetId, customConfig, sessionCount, schedule, timerState]);
-
-  // Timer interval
-  useEffect(() => {
-    if (!timerState.isRunning || !schedule) return;
-
-    const interval = setInterval(() => {
-      setTimerState((prev) => {
-        if (prev.remainingSeconds <= 1) {
-          const currentBlock = schedule.blocks[prev.currentBlockIndex];
-          const nextIndex = prev.currentBlockIndex + 1;
-          const wasWork = currentBlock?.phase === "work";
-
-          // Track work duration for stats
-          if (wasWork && currentBlock) {
-            lastWorkDurationRef.current = currentBlock.durationSeconds;
-          }
-
-          if (nextIndex >= schedule.blocks.length) {
-            // All done
-            sendNotification("Pomodoro", tNotif("allDone"));
-            return {
-              ...prev,
-              remainingSeconds: 0,
-              isRunning: false,
-              completedSessions: wasWork
-                ? prev.completedSessions + 1
-                : prev.completedSessions,
-            };
-          }
-
-          const nextBlock = schedule.blocks[nextIndex];
-          if (!nextBlock) {
-            return { ...prev, remainingSeconds: 0, isRunning: false };
-          }
-
-          // Send notification
-          if (wasWork) {
-            sendNotification("Pomodoro", tNotif("workDone"));
-          } else {
-            sendNotification("Pomodoro", tNotif("breakDone"));
-          }
-
-          return {
-            phase: nextBlock.phase,
-            currentBlockIndex: nextIndex,
-            remainingSeconds: nextBlock.durationSeconds,
-            isRunning: true,
-            completedSessions: wasWork
-              ? prev.completedSessions + 1
-              : prev.completedSessions,
-          };
-        }
-        return { ...prev, remainingSeconds: prev.remainingSeconds - 1 };
-      });
-    }, 1000);
-
-    return () => clearInterval(interval);
-  }, [timerState.isRunning, schedule, tNotif]);
-
-  // Record stats when a work session completes
-  const prevCompletedRef = useRef(0);
-  const presetIdRef = useRef(presetId);
-  presetIdRef.current = presetId;
-
-  useEffect(() => {
-    if (!loaded) return;
-    if (timerState.completedSessions > prevCompletedRef.current) {
-      const workDuration = lastWorkDurationRef.current;
-      setStats((prev) => {
-        const updated = upsertTodayStats(
-          prev,
-          presetIdRef.current,
-          workDuration,
-          0,
-        );
-        saveStats(updated);
-        return updated;
-      });
-    }
-    prevCompletedRef.current = timerState.completedSessions;
-  }, [timerState.completedSessions, loaded]);
-
-  // Handlers
-  const handleGenerateSchedule = useCallback(() => {
-    const preset = getActivePreset(presetId, customConfig);
-    const now = new Date();
-    let newSchedule: Schedule;
-
-    if (schedulingMode === "focusUntil") {
-      const [hours, minutes] = endTimeStr.split(":").map(Number);
-      const endTime = new Date();
-      endTime.setHours(hours ?? 0, minutes ?? 0, 0, 0);
-      if (endTime <= now) {
-        setEndTimeError(tFocusUntil("pastTime"));
-        return;
-      }
-      setEndTimeError(null);
-      newSchedule = scheduleFromTimeRange(preset, now, endTime);
-      if (newSchedule.blocks.length === 0) {
-        setEndTimeError(tFocusUntil("noFit"));
-        return;
-      }
-    } else {
-      newSchedule = generateSchedule(preset, sessionCount, now);
-    }
-
-    setSchedule(newSchedule);
-    const firstBlock = newSchedule.blocks[0];
-    setTimerState({
-      phase: firstBlock ? firstBlock.phase : "work",
-      currentBlockIndex: 0,
-      remainingSeconds: firstBlock ? firstBlock.durationSeconds : 0,
-      isRunning: false,
-      completedSessions: 0,
-    });
-    requestPermission();
-  }, [
+  const {
     presetId,
     customConfig,
+    setCustomConfig,
     sessionCount,
     schedulingMode,
     endTimeStr,
-    tFocusUntil,
-  ]);
+    endTimeError,
+    schedule,
+    timerState,
+    stats,
+    loaded,
+    isTimerActive,
+    isDone,
+    totalSessions,
+    presetSuggestion,
+    peakInfo,
+    totalSecondsForBlock,
+    activePreset,
+    handleStart,
+    handleStartAndGenerate,
+    handlePause,
+    handleReset,
+    handleSkip,
+    handlePresetChange,
+    handleSessionCountChange,
+    handleSchedulingModeChange,
+    handleEndTimeChange,
+  } = usePomodoro();
 
-  const handleStart = useCallback(() => {
-    if (!schedule) {
-      handleGenerateSchedule();
-      // Will start after schedule is set — use effect below
-      return;
-    }
-    setTimerState((prev) => ({ ...prev, isRunning: true }));
-  }, [schedule, handleGenerateSchedule]);
-
-  // Auto-start after generating schedule from handleStart
-  const pendingStartRef = useRef(false);
-  const handleStartAndGenerate = useCallback(() => {
-    if (!schedule) {
-      pendingStartRef.current = true;
-      handleGenerateSchedule();
-    } else {
-      setTimerState((prev) => ({ ...prev, isRunning: true }));
-    }
-  }, [schedule, handleGenerateSchedule]);
-
-  useEffect(() => {
-    if (schedule && pendingStartRef.current) {
-      pendingStartRef.current = false;
-      setTimerState((prev) => ({ ...prev, isRunning: true }));
-    }
-  }, [schedule]);
-
-  const handlePause = useCallback(() => {
-    setTimerState((prev) => ({ ...prev, isRunning: false }));
-  }, []);
-
-  const handleReset = useCallback(() => {
-    setSchedule(null);
-    setTimerState({
-      phase: "work",
-      currentBlockIndex: 0,
-      remainingSeconds: 0,
-      isRunning: false,
-      completedSessions: 0,
-    });
-    clearTimerState();
-  }, []);
-
-  const handleSkip = useCallback(() => {
-    if (!schedule) return;
-    const nextIndex = timerState.currentBlockIndex + 1;
-    if (nextIndex >= schedule.blocks.length) {
-      handleReset();
-      return;
-    }
-    const nextBlock = schedule.blocks[nextIndex];
-    if (!nextBlock) {
-      handleReset();
-      return;
-    }
-    setTimerState((prev) => ({
-      ...prev,
-      phase: nextBlock.phase,
-      currentBlockIndex: nextIndex,
-      remainingSeconds: nextBlock.durationSeconds,
-      completedSessions:
-        prev.phase === "work"
-          ? prev.completedSessions + 1
-          : prev.completedSessions,
-    }));
-  }, [schedule, timerState.currentBlockIndex, handleReset]);
-
-  const handlePresetChange = useCallback(
-    (id: PresetId) => {
-      setPresetId(id);
-      setEndTimeError(null);
-      const preset = id === "custom" ? customConfig : PRESETS[id];
-      setSessionCount(Math.min(DEFAULT_SESSION_COUNT, preset.maxDailySessions));
-      // Reset schedule when preset changes
-      if (schedule && !timerState.isRunning) {
-        setSchedule(null);
-        setTimerState({
-          phase: "work",
-          currentBlockIndex: 0,
-          remainingSeconds: 0,
-          isRunning: false,
-          completedSessions: 0,
-        });
-      }
-    },
-    [schedule, timerState.isRunning, customConfig],
-  );
-
-  const handleSessionCountChange = useCallback(
-    (count: number) => {
-      const preset = getActivePreset(presetId, customConfig);
-      setSessionCount(Math.max(1, Math.min(preset.maxDailySessions, count)));
-    },
-    [presetId, customConfig],
-  );
-
-  const isTimerActive = schedule !== null;
-  const isDone =
-    isTimerActive &&
-    !timerState.isRunning &&
-    timerState.remainingSeconds === 0 &&
-    timerState.currentBlockIndex > 0;
-  const totalSessions = schedule
-    ? schedule.blocks.filter((b) => b.phase === "work").length
-    : sessionCount;
-
-  // Preset suggestion for focusUntil mode
-  const presetSuggestion = useMemo(() => {
-    if (schedulingMode !== "focusUntil" || isTimerActive) return null;
-    const [hours, minutes] = endTimeStr.split(":").map(Number);
-    const now = new Date();
-    const endTime = new Date();
-    endTime.setHours(hours ?? 0, minutes ?? 0, 0, 0);
-    if (endTime <= now) return null;
-    const preset = getActivePreset(presetId, customConfig);
-    return suggestBetterPreset(preset, now, endTime);
-  }, [schedulingMode, endTimeStr, presetId, customConfig, isTimerActive]);
-
-  // Time-of-day hint
-  const peakInfo = getPeakFocusInfo(new Date().getHours());
   const phaseLabel =
     timerState.phase === "work"
       ? tTimer("work")
       : timerState.phase === "longBreak"
         ? tTimer("longBreak")
         : tTimer("break");
-
-  const currentBlock = schedule?.blocks[timerState.currentBlockIndex];
-  const totalSecondsForBlock = currentBlock?.durationSeconds ?? 0;
 
   return (
     <div className="space-y-6">
@@ -415,10 +79,7 @@ export function PomodoroApp() {
           <div className="flex gap-2">
             <button
               type="button"
-              onClick={() => {
-                setSchedulingMode("sessions");
-                setEndTimeError(null);
-              }}
+              onClick={() => handleSchedulingModeChange("sessions")}
               className={`flex-1 rounded-lg border px-3 py-1.5 text-sm transition-colors ${
                 schedulingMode === "sessions"
                   ? "border-primary bg-primary/10 font-medium"
@@ -429,7 +90,7 @@ export function PomodoroApp() {
             </button>
             <button
               type="button"
-              onClick={() => setSchedulingMode("focusUntil")}
+              onClick={() => handleSchedulingModeChange("focusUntil")}
               className={`flex-1 rounded-lg border px-3 py-1.5 text-sm transition-colors ${
                 schedulingMode === "focusUntil"
                   ? "border-primary bg-primary/10 font-medium"
@@ -461,10 +122,7 @@ export function PomodoroApp() {
                   variant="outline"
                   size="xs"
                   onClick={() => handleSessionCountChange(sessionCount + 1)}
-                  disabled={
-                    sessionCount >=
-                    getActivePreset(presetId, customConfig).maxDailySessions
-                  }
+                  disabled={sessionCount >= activePreset.maxDailySessions}
                 >
                   +
                 </Button>
@@ -479,10 +137,7 @@ export function PomodoroApp() {
                 <input
                   type="time"
                   value={endTimeStr}
-                  onChange={(e) => {
-                    setEndTimeStr(e.target.value);
-                    setEndTimeError(null);
-                  }}
+                  onChange={(e) => handleEndTimeChange(e.target.value)}
                   className="rounded-lg border border-border bg-card px-3 py-1.5 text-sm"
                 />
               </div>

--- a/components/pomodoro/use-pomodoro.ts
+++ b/components/pomodoro/use-pomodoro.ts
@@ -1,0 +1,428 @@
+import { useTranslations } from "next-intl";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { PRESETS } from "@/lib/pomodoro/constants";
+import {
+  requestPermission,
+  sendNotification,
+} from "@/lib/pomodoro/notifications";
+import {
+  generateSchedule,
+  getPeakFocusInfo,
+  scheduleFromTimeRange,
+  suggestBetterPreset,
+} from "@/lib/pomodoro/scheduler";
+import {
+  clearTimerState,
+  getDefaultCustomConfig,
+  loadStats,
+  loadTimerState,
+  saveStats,
+  saveTimerState,
+  upsertTodayStats,
+} from "@/lib/pomodoro/storage";
+import type {
+  PresetConfig,
+  PresetId,
+  Schedule,
+  SessionRecord,
+  TimerState,
+} from "@/lib/pomodoro/types";
+
+export type SchedulingMode = "sessions" | "focusUntil";
+
+const DEFAULT_SESSION_COUNT = 4;
+
+function getDefaultEndTime(): string {
+  const d = new Date();
+  d.setHours(d.getHours() + 2, 0, 0, 0);
+  return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+}
+
+function getActivePreset(
+  presetId: PresetId,
+  customConfig: PresetConfig,
+): PresetConfig {
+  return presetId === "custom" ? customConfig : PRESETS[presetId];
+}
+
+export function usePomodoro() {
+  const tNotif = useTranslations("pomodoro.notifications");
+  const tFocusUntil = useTranslations("pomodoro.focusUntil");
+
+  // Error state
+  const [endTimeError, setEndTimeError] = useState<string | null>(null);
+
+  // Config state
+  const [presetId, setPresetId] = useState<PresetId>("pomodoro");
+  const [customConfig, setCustomConfig] = useState<PresetConfig>(
+    getDefaultCustomConfig(),
+  );
+  const [sessionCount, setSessionCount] = useState(DEFAULT_SESSION_COUNT);
+  const [schedulingMode, setSchedulingMode] =
+    useState<SchedulingMode>("sessions");
+  const [endTimeStr, setEndTimeStr] = useState(getDefaultEndTime);
+
+  // Schedule & timer
+  const [schedule, setSchedule] = useState<Schedule | null>(null);
+  const [timerState, setTimerState] = useState<TimerState>({
+    phase: "work",
+    currentBlockIndex: 0,
+    remainingSeconds: 0,
+    isRunning: false,
+    completedSessions: 0,
+  });
+
+  // Stats
+  const [stats, setStats] = useState<SessionRecord[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  // Track last completed work block for stats
+  const lastWorkDurationRef = useRef(0);
+
+  // Load from localStorage on mount
+  useEffect(() => {
+    const stored = loadTimerState();
+    if (stored) {
+      setPresetId(stored.presetId);
+      setCustomConfig(stored.customConfig);
+      setSessionCount(stored.sessionCount);
+      setSchedule(stored.schedule);
+
+      // Handle time drift if timer was running
+      let restoredTimer = stored.timerState;
+      if (restoredTimer.isRunning) {
+        const elapsed = Math.floor(
+          (Date.now() - new Date(stored.savedAt).getTime()) / 1000,
+        );
+        restoredTimer = {
+          ...restoredTimer,
+          remainingSeconds: Math.max(
+            0,
+            restoredTimer.remainingSeconds - elapsed,
+          ),
+          isRunning: false, // Pause on restore, let user decide
+        };
+      }
+      setTimerState(restoredTimer);
+    }
+
+    setStats(loadStats());
+    setLoaded(true);
+  }, []);
+
+  // Save timer state on changes
+  useEffect(() => {
+    if (!loaded || !schedule) return;
+    saveTimerState({
+      presetId,
+      customConfig,
+      sessionCount,
+      schedule,
+      timerState,
+      savedAt: new Date().toISOString(),
+    });
+  }, [loaded, presetId, customConfig, sessionCount, schedule, timerState]);
+
+  // Timer interval
+  useEffect(() => {
+    if (!timerState.isRunning || !schedule) return;
+
+    const interval = setInterval(() => {
+      setTimerState((prev) => {
+        if (prev.remainingSeconds <= 1) {
+          const currentBlock = schedule.blocks[prev.currentBlockIndex];
+          const nextIndex = prev.currentBlockIndex + 1;
+          const wasWork = currentBlock?.phase === "work";
+
+          // Track work duration for stats
+          if (wasWork && currentBlock) {
+            lastWorkDurationRef.current = currentBlock.durationSeconds;
+          }
+
+          if (nextIndex >= schedule.blocks.length) {
+            // All done
+            sendNotification("Pomodoro", tNotif("allDone"));
+            return {
+              ...prev,
+              remainingSeconds: 0,
+              isRunning: false,
+              completedSessions: wasWork
+                ? prev.completedSessions + 1
+                : prev.completedSessions,
+            };
+          }
+
+          const nextBlock = schedule.blocks[nextIndex];
+          if (!nextBlock) {
+            return { ...prev, remainingSeconds: 0, isRunning: false };
+          }
+
+          // Send notification
+          if (wasWork) {
+            sendNotification("Pomodoro", tNotif("workDone"));
+          } else {
+            sendNotification("Pomodoro", tNotif("breakDone"));
+          }
+
+          return {
+            phase: nextBlock.phase,
+            currentBlockIndex: nextIndex,
+            remainingSeconds: nextBlock.durationSeconds,
+            isRunning: true,
+            completedSessions: wasWork
+              ? prev.completedSessions + 1
+              : prev.completedSessions,
+          };
+        }
+        return { ...prev, remainingSeconds: prev.remainingSeconds - 1 };
+      });
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [timerState.isRunning, schedule, tNotif]);
+
+  // Record stats when a work session completes
+  const prevCompletedRef = useRef(0);
+  const presetIdRef = useRef(presetId);
+  presetIdRef.current = presetId;
+
+  useEffect(() => {
+    if (!loaded) return;
+    if (timerState.completedSessions > prevCompletedRef.current) {
+      const workDuration = lastWorkDurationRef.current;
+      setStats((prev) => {
+        const updated = upsertTodayStats(
+          prev,
+          presetIdRef.current,
+          workDuration,
+          0,
+        );
+        saveStats(updated);
+        return updated;
+      });
+    }
+    prevCompletedRef.current = timerState.completedSessions;
+  }, [timerState.completedSessions, loaded]);
+
+  // Handlers
+  const handleGenerateSchedule = useCallback(() => {
+    const preset = getActivePreset(presetId, customConfig);
+    const now = new Date();
+    let newSchedule: Schedule;
+
+    if (schedulingMode === "focusUntil") {
+      const [hours, minutes] = endTimeStr.split(":").map(Number);
+      const endTime = new Date();
+      endTime.setHours(hours ?? 0, minutes ?? 0, 0, 0);
+      if (endTime <= now) {
+        setEndTimeError(tFocusUntil("pastTime"));
+        return;
+      }
+      setEndTimeError(null);
+      newSchedule = scheduleFromTimeRange(preset, now, endTime);
+      if (newSchedule.blocks.length === 0) {
+        setEndTimeError(tFocusUntil("noFit"));
+        return;
+      }
+    } else {
+      newSchedule = generateSchedule(preset, sessionCount, now);
+    }
+
+    setSchedule(newSchedule);
+    const firstBlock = newSchedule.blocks[0];
+    setTimerState({
+      phase: firstBlock ? firstBlock.phase : "work",
+      currentBlockIndex: 0,
+      remainingSeconds: firstBlock ? firstBlock.durationSeconds : 0,
+      isRunning: false,
+      completedSessions: 0,
+    });
+    requestPermission();
+  }, [
+    presetId,
+    customConfig,
+    sessionCount,
+    schedulingMode,
+    endTimeStr,
+    tFocusUntil,
+  ]);
+
+  const handleStart = useCallback(() => {
+    if (!schedule) {
+      handleGenerateSchedule();
+      // Will start after schedule is set — use effect below
+      return;
+    }
+    setTimerState((prev) => ({ ...prev, isRunning: true }));
+  }, [schedule, handleGenerateSchedule]);
+
+  // Auto-start after generating schedule from handleStart
+  const pendingStartRef = useRef(false);
+  const handleStartAndGenerate = useCallback(() => {
+    if (!schedule) {
+      pendingStartRef.current = true;
+      handleGenerateSchedule();
+    } else {
+      setTimerState((prev) => ({ ...prev, isRunning: true }));
+    }
+  }, [schedule, handleGenerateSchedule]);
+
+  useEffect(() => {
+    if (schedule && pendingStartRef.current) {
+      pendingStartRef.current = false;
+      setTimerState((prev) => ({ ...prev, isRunning: true }));
+    }
+  }, [schedule]);
+
+  const handlePause = useCallback(() => {
+    setTimerState((prev) => ({ ...prev, isRunning: false }));
+  }, []);
+
+  const handleReset = useCallback(() => {
+    setSchedule(null);
+    setTimerState({
+      phase: "work",
+      currentBlockIndex: 0,
+      remainingSeconds: 0,
+      isRunning: false,
+      completedSessions: 0,
+    });
+    clearTimerState();
+  }, []);
+
+  const handleSkip = useCallback(() => {
+    if (!schedule) return;
+    const nextIndex = timerState.currentBlockIndex + 1;
+    if (nextIndex >= schedule.blocks.length) {
+      handleReset();
+      return;
+    }
+    const nextBlock = schedule.blocks[nextIndex];
+    if (!nextBlock) {
+      handleReset();
+      return;
+    }
+    setTimerState((prev) => ({
+      ...prev,
+      phase: nextBlock.phase,
+      currentBlockIndex: nextIndex,
+      remainingSeconds: nextBlock.durationSeconds,
+      completedSessions:
+        prev.phase === "work"
+          ? prev.completedSessions + 1
+          : prev.completedSessions,
+    }));
+  }, [schedule, timerState.currentBlockIndex, handleReset]);
+
+  const handlePresetChange = useCallback(
+    (id: PresetId) => {
+      setPresetId(id);
+      setEndTimeError(null);
+      const preset = id === "custom" ? customConfig : PRESETS[id];
+      setSessionCount(Math.min(DEFAULT_SESSION_COUNT, preset.maxDailySessions));
+      // Reset schedule when preset changes
+      if (schedule && !timerState.isRunning) {
+        setSchedule(null);
+        setTimerState({
+          phase: "work",
+          currentBlockIndex: 0,
+          remainingSeconds: 0,
+          isRunning: false,
+          completedSessions: 0,
+        });
+      }
+    },
+    [schedule, timerState.isRunning, customConfig],
+  );
+
+  const handleSessionCountChange = useCallback(
+    (count: number) => {
+      const preset = getActivePreset(presetId, customConfig);
+      setSessionCount(Math.max(1, Math.min(preset.maxDailySessions, count)));
+    },
+    [presetId, customConfig],
+  );
+
+  const handleSchedulingModeChange = useCallback((mode: SchedulingMode) => {
+    setSchedulingMode(mode);
+    if (mode === "sessions") {
+      setEndTimeError(null);
+    }
+  }, []);
+
+  const handleEndTimeChange = useCallback((value: string) => {
+    setEndTimeStr(value);
+    setEndTimeError(null);
+  }, []);
+
+  // Derived values
+  const isTimerActive = schedule !== null;
+  const isDone =
+    isTimerActive &&
+    !timerState.isRunning &&
+    timerState.remainingSeconds === 0 &&
+    timerState.currentBlockIndex > 0;
+  const totalSessions = schedule
+    ? schedule.blocks.filter((b) => b.phase === "work").length
+    : sessionCount;
+
+  // Preset suggestion for focusUntil mode
+  const presetSuggestion = useMemo(() => {
+    if (schedulingMode !== "focusUntil" || isTimerActive) return null;
+    const [hours, minutes] = endTimeStr.split(":").map(Number);
+    const now = new Date();
+    const endTime = new Date();
+    endTime.setHours(hours ?? 0, minutes ?? 0, 0, 0);
+    if (endTime <= now) return null;
+    const preset = getActivePreset(presetId, customConfig);
+    return suggestBetterPreset(preset, now, endTime);
+  }, [schedulingMode, endTimeStr, presetId, customConfig, isTimerActive]);
+
+  // Time-of-day hint
+  const peakInfo = getPeakFocusInfo(new Date().getHours());
+
+  const currentBlock = schedule?.blocks[timerState.currentBlockIndex];
+  const totalSecondsForBlock = currentBlock?.durationSeconds ?? 0;
+
+  const activePreset = getActivePreset(presetId, customConfig);
+
+  return {
+    // Config state
+    presetId,
+    customConfig,
+    setCustomConfig,
+    sessionCount,
+    schedulingMode,
+    endTimeStr,
+    endTimeError,
+
+    // Schedule & timer
+    schedule,
+    timerState,
+
+    // Stats
+    stats,
+    loaded,
+
+    // Derived values
+    isTimerActive,
+    isDone,
+    totalSessions,
+    presetSuggestion,
+    peakInfo,
+    totalSecondsForBlock,
+    activePreset,
+
+    // Handlers
+    handleGenerateSchedule,
+    handleStart,
+    handleStartAndGenerate,
+    handlePause,
+    handleReset,
+    handleSkip,
+    handlePresetChange,
+    handleSessionCountChange,
+    handleSchedulingModeChange,
+    handleEndTimeChange,
+  };
+}

--- a/components/site-nav.tsx
+++ b/components/site-nav.tsx
@@ -2,88 +2,39 @@
 
 import Link from "next/link";
 import { useLocale, useTranslations } from "next-intl";
-import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 
 export function SiteNav() {
   const locale = useLocale();
   const t = useTranslations("nav");
-  const [menuOpen, setMenuOpen] = useState(false);
-  const menuRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const handleClick = (event: MouseEvent) => {
-      if (!menuRef.current?.contains(event.target as Node)) {
-        setMenuOpen(false);
-      }
-    };
-
-    const handleKey = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        setMenuOpen(false);
-      }
-    };
-
-    document.addEventListener("mousedown", handleClick);
-    document.addEventListener("keydown", handleKey);
-
-    return () => {
-      document.removeEventListener("mousedown", handleClick);
-      document.removeEventListener("keydown", handleKey);
-    };
-  }, []);
 
   return (
-    <div ref={menuRef} className="relative">
-      <Button
-        variant="ghost"
-        size="sm"
-        onClick={() => setMenuOpen((prev) => !prev)}
-        aria-expanded={menuOpen}
-        aria-haspopup="menu"
-      >
-        {t("menu")}
-      </Button>
-
-      {menuOpen && (
-        <div
-          className="absolute right-0 mt-2 w-40 rounded-xl border border-border bg-popover p-2 shadow-md"
-          role="menu"
-        >
-          <Link
-            href={`/${locale}`}
-            className="block rounded-md px-2 py-1 text-sm hover:bg-accent"
-            onClick={() => setMenuOpen(false)}
-            role="menuitem"
-          >
-            {t("home")}
-          </Link>
-          <Link
-            href={`/${locale}/blog`}
-            className="block rounded-md px-2 py-1 text-sm hover:bg-accent"
-            onClick={() => setMenuOpen(false)}
-            role="menuitem"
-          >
-            {t("blog")}
-          </Link>
-          <Link
-            href={`/${locale}/games`}
-            className="block rounded-md px-2 py-1 text-sm hover:bg-accent"
-            onClick={() => setMenuOpen(false)}
-            role="menuitem"
-          >
-            {t("games")}
-          </Link>
-          <Link
-            href={`/${locale}/tools`}
-            className="block rounded-md px-2 py-1 text-sm hover:bg-accent"
-            onClick={() => setMenuOpen(false)}
-            role="menuitem"
-          >
-            {t("tools")}
-          </Link>
-        </div>
-      )}
-    </div>
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="sm">
+          {t("menu")}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem asChild>
+          <Link href={`/${locale}`}>{t("home")}</Link>
+        </DropdownMenuItem>
+        <DropdownMenuItem asChild>
+          <Link href={`/${locale}/blog`}>{t("blog")}</Link>
+        </DropdownMenuItem>
+        <DropdownMenuItem asChild>
+          <Link href={`/${locale}/games`}>{t("games")}</Link>
+        </DropdownMenuItem>
+        <DropdownMenuItem asChild>
+          <Link href={`/${locale}/tools`}>{t("tools")}</Link>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/components/wordle/solver/solver-demo.tsx
+++ b/components/wordle/solver/solver-demo.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Pause, Play, RotateCcw, SkipForward } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import type { TileData } from "@/lib/wordle";
@@ -17,7 +18,6 @@ import { WordleBoard } from "../wordle-board";
 
 interface SolverDemoProps {
   wordList: string[];
-  locale: string;
 }
 
 type DemoStatus = "ready" | "solving" | "solved" | "failed";
@@ -30,7 +30,9 @@ const SPEEDS = [
 
 const DEFAULT_SPEED = SPEEDS[1];
 
-export function SolverDemo({ wordList, locale }: SolverDemoProps) {
+export function SolverDemo({ wordList }: SolverDemoProps) {
+  const t = useTranslations("games.wordle.solver");
+
   const [solution, setSolution] = useState(() => getRandomWord(wordList));
   const [guesses, setGuesses] = useState<string[]>([]);
   const [solverState, setSolverState] = useState<SolverState>(() =>
@@ -41,7 +43,6 @@ export function SolverDemo({ wordList, locale }: SolverDemoProps) {
   const [speedIndex, setSpeedIndex] = useState(1);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const isDE = locale === "de";
   const currentSpeed = SPEEDS[speedIndex] ?? DEFAULT_SPEED;
 
   // Build board rows from guesses
@@ -146,19 +147,13 @@ export function SolverDemo({ wordList, locale }: SolverDemoProps) {
   const getStatusText = () => {
     switch (status) {
       case "ready":
-        return isDE ? "Bereit zum Lösen" : "Ready to solve";
+        return t("status.ready");
       case "solving":
-        return isDE
-          ? `Löst... (${solverState.possibleWords.length} Wörter übrig)`
-          : `Solving... (${solverState.possibleWords.length} words left)`;
+        return `${t("status.solving")} (${solverState.possibleWords.length})`;
       case "solved":
-        return isDE
-          ? `Gelöst in ${guesses.length} Versuchen!`
-          : `Solved in ${guesses.length} guesses!`;
+        return t("status.solved", { count: guesses.length });
       case "failed":
-        return isDE
-          ? `Fehlgeschlagen. Das Wort war ${solution}`
-          : `Failed. The word was ${solution}`;
+        return t("failed", { word: solution });
     }
   };
 
@@ -193,7 +188,7 @@ export function SolverDemo({ wordList, locale }: SolverDemoProps) {
             className="gap-2"
           >
             <Play className="size-4" />
-            {isDE ? "Start" : "Play"}
+            {t("controls.play")}
           </Button>
         ) : (
           <Button
@@ -203,7 +198,7 @@ export function SolverDemo({ wordList, locale }: SolverDemoProps) {
             className="gap-2"
           >
             <Pause className="size-4" />
-            {isDE ? "Pause" : "Pause"}
+            {t("controls.pause")}
           </Button>
         )}
 
@@ -215,7 +210,7 @@ export function SolverDemo({ wordList, locale }: SolverDemoProps) {
           className="gap-2"
         >
           <SkipForward className="size-4" />
-          {isDE ? "Schritt" : "Step"}
+          {t("controls.step")}
         </Button>
 
         <Button
@@ -225,7 +220,7 @@ export function SolverDemo({ wordList, locale }: SolverDemoProps) {
           className="gap-2"
         >
           <RotateCcw className="size-4" />
-          {isDE ? "Neustart" : "Reset"}
+          {t("controls.reset")}
         </Button>
 
         <Button
@@ -241,7 +236,7 @@ export function SolverDemo({ wordList, locale }: SolverDemoProps) {
       {/* Solution reveal (when game is over) */}
       {(status === "solved" || status === "failed") && (
         <div className="text-sm text-muted-foreground">
-          {isDE ? "Lösung" : "Solution"}:{" "}
+          {t("solution")}:{" "}
           <span className="font-mono font-bold">{solution}</span>
         </div>
       )}

--- a/components/wordle/solver/solver-hint-button.tsx
+++ b/components/wordle/solver/solver-hint-button.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Lightbulb } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import type { ScoredWord } from "@/lib/wordle/solver";
@@ -9,7 +10,6 @@ interface SolverHintButtonProps {
   suggestions: ScoredWord[];
   possibleWordsCount: number;
   disabled?: boolean;
-  locale: string;
   onToggle?: (enabled: boolean) => void;
 }
 
@@ -17,11 +17,10 @@ export function SolverHintButton({
   suggestions,
   possibleWordsCount,
   disabled,
-  locale,
   onToggle,
 }: SolverHintButtonProps) {
+  const t = useTranslations("games.wordle.solver");
   const [showHint, setShowHint] = useState(false);
-  const isDE = locale === "de";
 
   useEffect(() => {
     onToggle?.(showHint);
@@ -41,22 +40,20 @@ export function SolverHintButton({
         className="gap-2"
       >
         <Lightbulb className="size-4" />
-        {isDE ? "Hinweis" : "Hint"}
+        {t("hint")}
       </Button>
 
       {showHint && suggestions.length > 0 && (
         <div className="bg-muted rounded-md p-3 text-sm space-y-2 min-w-[200px]">
           <div className="text-muted-foreground">
-            {isDE ? "Verbleibende Wörter" : "Words remaining"}:{" "}
+            {t("wordsRemaining")}:{" "}
             <span className="font-medium text-foreground">
               {possibleWordsCount}
             </span>
           </div>
 
           <div className="space-y-1">
-            <div className="text-muted-foreground">
-              {isDE ? "Beste Vorschläge" : "Best guesses"}:
-            </div>
+            <div className="text-muted-foreground">{t("bestGuesses")}:</div>
             <ul className="space-y-1">
               {suggestions.slice(0, 3).map((s, i) => (
                 <li key={s.word} className="flex items-center justify-between">
@@ -65,7 +62,7 @@ export function SolverHintButton({
                   </span>
                   {s.isPossibleSolution && (
                     <span className="text-xs text-muted-foreground ml-2">
-                      {isDE ? "(möglich)" : "(possible)"}
+                      ({t("possible")})
                     </span>
                   )}
                 </li>
@@ -77,7 +74,7 @@ export function SolverHintButton({
 
       {showHint && suggestions.length === 0 && (
         <div className="bg-muted rounded-md p-3 text-sm text-muted-foreground">
-          {isDE ? "Lädt..." : "Loading..."}
+          {t("loading")}
         </div>
       )}
     </div>

--- a/components/wordle/solver/solver-input-grid.tsx
+++ b/components/wordle/solver/solver-input-grid.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useLocale, useTranslations } from "next-intl";
 import { useCallback, useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { MAX_GUESSES, WORD_LENGTH } from "@/lib/wordle";
@@ -22,7 +23,6 @@ interface SolverInputGridProps {
   onLetterInput: (letter: string) => void;
   onBackspace: () => void;
   onSubmit: () => void;
-  locale: string;
 }
 
 const STATE_COLORS: Record<ConstraintState | "empty", string> = {
@@ -41,9 +41,9 @@ export function SolverInputGrid({
   onLetterInput,
   onBackspace,
   onSubmit,
-  locale,
 }: SolverInputGridProps) {
-  const isDE = locale === "de";
+  const locale = useLocale();
+  const t = useTranslations("games.wordle.solver");
 
   // Handle keyboard input
   useEffect(() => {
@@ -76,9 +76,10 @@ export function SolverInputGrid({
     <div className="flex flex-col items-center gap-4">
       {/* Instructions */}
       <p className="text-sm text-muted-foreground text-center">
-        {isDE
-          ? "Tippe dein Wort ein, dann klicke auf Kacheln um den Status zu ändern"
-          : "Type your word, then click tiles to change their status"}
+        {t("enterGuess")}
+      </p>
+      <p className="text-sm text-muted-foreground text-center">
+        {t("clickToMark")}
       </p>
 
       {/* Grid */}
@@ -121,22 +122,22 @@ export function SolverInputGrid({
           rows[currentRowIndex]?.tiles.some((t) => !t.letter)
         }
       >
-        {isDE ? "Vorschlag holen" : "Get Suggestions"}
+        {t("getSuggestions")}
       </Button>
 
       {/* Legend */}
       <div className="flex gap-4 text-sm">
         <div className="flex items-center gap-1.5">
           <div className="size-4 bg-muted border border-muted-foreground/20" />
-          <span>{isDE ? "Falsch" : "Absent"}</span>
+          <span>{t("absent")}</span>
         </div>
         <div className="flex items-center gap-1.5">
           <div className="size-4 bg-[var(--wordle-present)]" />
-          <span>{isDE ? "Falsche Stelle" : "Present"}</span>
+          <span>{t("present")}</span>
         </div>
         <div className="flex items-center gap-1.5">
           <div className="size-4 bg-[var(--wordle-correct)]" />
-          <span>{isDE ? "Richtig" : "Correct"}</span>
+          <span>{t("correct")}</span>
         </div>
       </div>
     </div>

--- a/components/wordle/solver/solver-suggestions.tsx
+++ b/components/wordle/solver/solver-suggestions.tsx
@@ -1,24 +1,23 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import type { ScoredWord } from "@/lib/wordle/solver";
 
 interface SolverSuggestionsProps {
   suggestions: ScoredWord[];
   possibleWordsCount: number;
-  locale: string;
 }
 
 export function SolverSuggestions({
   suggestions,
   possibleWordsCount,
-  locale,
 }: SolverSuggestionsProps) {
-  const isDE = locale === "de";
+  const t = useTranslations("games.wordle.solver");
 
   if (suggestions.length === 0) {
     return (
       <div className="text-muted-foreground text-center py-4">
-        {isDE ? "Keine passenden Worte gefunden" : "No matching words found"}
+        {t("noMatches")}
       </div>
     );
   }
@@ -26,16 +25,12 @@ export function SolverSuggestions({
   return (
     <div className="space-y-4">
       <div className="text-center">
-        <span className="text-muted-foreground">
-          {isDE ? "Verbleibende Worte" : "Words remaining"}:{" "}
-        </span>
+        <span className="text-muted-foreground">{t("wordsRemaining")}: </span>
         <span className="font-bold text-xl">{possibleWordsCount}</span>
       </div>
 
       <div className="space-y-2">
-        <h3 className="font-medium text-center">
-          {isDE ? "Empfohlene Vorschläge" : "Recommended guesses"}
-        </h3>
+        <h3 className="font-medium text-center">{t("recommended")}</h3>
 
         <div className="space-y-1">
           {suggestions.map((s, i) => (
@@ -50,11 +45,11 @@ export function SolverSuggestions({
 
               <div className="flex items-center gap-2 text-sm">
                 <span className="text-muted-foreground">
-                  {isDE ? "Info" : "Info"}: {s.score.toFixed(2)} bits
+                  {t("info")}: {s.score.toFixed(2)} bits
                 </span>
                 {s.isPossibleSolution && (
                   <span className="bg-[var(--wordle-correct)] text-white dark:text-primary-foreground px-2 py-0.5 rounded text-xs">
-                    {isDE ? "Möglich" : "Possible"}
+                    {t("possible")}
                   </span>
                 )}
               </div>

--- a/components/wordle/use-wordle.ts
+++ b/components/wordle/use-wordle.ts
@@ -1,7 +1,8 @@
 "use client";
 
+import { useLocale, useTranslations } from "next-intl";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import type { GameState, StoredGameState, TileData } from "@/lib/wordle";
+import type { GameState, TileData } from "@/lib/wordle";
 import {
   createCurrentRow,
   createEmptyRow,
@@ -12,51 +13,13 @@ import {
   updateLetterStates,
   WORD_LENGTH,
 } from "@/lib/wordle";
+import {
+  clearGameState,
+  loadGameState,
+  saveGameState,
+} from "@/lib/wordle/storage";
 import { VALID_WORDS_DE, WORDS_DE } from "@/lib/wordle/words-de";
 import { VALID_WORDS_EN, WORDS_EN } from "@/lib/wordle/words-en";
-
-const STORAGE_KEY_PREFIX = "wordle-state-";
-
-function getStorageKey(locale: string): string {
-  return `${STORAGE_KEY_PREFIX}${locale}`;
-}
-
-function loadGameState(locale: string): StoredGameState | null {
-  if (typeof window === "undefined") return null;
-  try {
-    const stored = localStorage.getItem(getStorageKey(locale));
-    if (!stored) return null;
-    return JSON.parse(stored) as StoredGameState;
-  } catch {
-    return null;
-  }
-}
-
-function saveGameState(state: GameState, locale: string): void {
-  if (typeof window === "undefined") return;
-  try {
-    const toStore: StoredGameState = {
-      solution: state.solution,
-      guesses: state.guesses,
-      gameStatus: state.gameStatus,
-      letterStates: state.letterStates,
-      locale,
-      timestamp: Date.now(),
-    };
-    localStorage.setItem(getStorageKey(locale), JSON.stringify(toStore));
-  } catch {
-    // Ignore storage errors
-  }
-}
-
-function clearGameState(locale: string): void {
-  if (typeof window === "undefined") return;
-  try {
-    localStorage.removeItem(getStorageKey(locale));
-  } catch {
-    // Ignore storage errors
-  }
-}
 
 export type MessageType = "error" | "success" | "info";
 
@@ -65,7 +28,10 @@ export interface GameMessage {
   type: MessageType;
 }
 
-export function useWordle(locale: string) {
+export function useWordle() {
+  const locale = useLocale();
+  const t = useTranslations("games.wordle");
+
   const words = locale === "de" ? WORDS_DE : WORDS_EN;
   const validWords = locale === "de" ? VALID_WORDS_DE : VALID_WORDS_EN;
 
@@ -146,19 +112,13 @@ export function useWordle(locale: string) {
     const guess = gameState.currentGuess;
 
     if (guess.length < WORD_LENGTH) {
-      showMessage(
-        locale === "de" ? "Nicht genug Buchstaben" : "Not enough letters",
-        "error",
-      );
+      showMessage(t("notEnough"), "error");
       setShakeRow(gameState.guesses.length);
       return;
     }
 
     if (!isValidWord(guess, validWords)) {
-      showMessage(
-        locale === "de" ? "Nicht in der Wortliste" : "Not in word list",
-        "error",
-      );
+      showMessage(t("invalidWord"), "error");
       setShakeRow(gameState.guesses.length);
       // Clear the invalid guess so user can try again
       setGameState((prev) => ({
@@ -180,15 +140,10 @@ export function useWordle(locale: string) {
     let newStatus: GameState["gameStatus"] = "playing";
     if (isWin) {
       newStatus = "won";
-      showMessage(locale === "de" ? "Gewonnen!" : "You won!", "success");
+      showMessage(t("youWin"), "success");
     } else if (isLastGuess) {
       newStatus = "lost";
-      showMessage(
-        locale === "de"
-          ? `Das Wort war ${gameState.solution}`
-          : `The word was ${gameState.solution}`,
-        "info",
-      );
+      showMessage(t("youLose", { word: gameState.solution }), "info");
     }
 
     setGameState((prev) => ({
@@ -206,7 +161,7 @@ export function useWordle(locale: string) {
     gameState.letterStates,
     validWords,
     showMessage,
-    locale,
+    t,
   ]);
 
   const resetGame = useCallback(() => {

--- a/components/wordle/wordle-game.tsx
+++ b/components/wordle/wordle-game.tsx
@@ -2,6 +2,7 @@
 
 import { Bot, Keyboard, RotateCcw } from "lucide-react";
 import Link from "next/link";
+import { useLocale, useTranslations } from "next-intl";
 import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { WORDS_DE, WORDS_EN } from "@/lib/wordle";
@@ -10,11 +11,9 @@ import { useWordle } from "./use-wordle";
 import { WordleBoard } from "./wordle-board";
 import { WordleKeyboard } from "./wordle-keyboard";
 
-interface WordleGameProps {
-  locale: string;
-}
-
-export function WordleGame({ locale }: WordleGameProps) {
+export function WordleGame() {
+  const locale = useLocale();
+  const t = useTranslations("games.wordle");
   const inputRef = useRef<HTMLInputElement>(null);
   const {
     gameState,
@@ -27,7 +26,7 @@ export function WordleGame({ locale }: WordleGameProps) {
     removeLetter,
     submitGuess,
     resetGame,
-  } = useWordle(locale);
+  } = useWordle();
 
   const [hintEnabled, setHintEnabled] = useState(false);
   const [showKeyboard, setShowKeyboard] = useState(() => {
@@ -133,7 +132,6 @@ export function WordleGame({ locale }: WordleGameProps) {
           <SolverHintButton
             suggestions={suggestions}
             possibleWordsCount={possibleWordsCount}
-            locale={locale}
             onToggle={setHintEnabled}
           />
         )}
@@ -145,20 +143,18 @@ export function WordleGame({ locale }: WordleGameProps) {
           className="gap-2"
         >
           <RotateCcw className="size-4" />
-          {locale === "de" ? "Neu starten" : "Reset"}
+          {t("reset")}
         </Button>
 
         <Button variant="ghost" size="sm" asChild>
           <Link href={`/${locale}/games/wordle/demo`} className="gap-2">
             <Bot className="size-4" />
-            {locale === "de" ? "Demo" : "Demo"}
+            Demo
           </Link>
         </Button>
 
         <Button variant="ghost" size="sm" asChild>
-          <Link href={`/${locale}/games/wordle/solver`}>
-            {locale === "de" ? "Solver" : "Solver"}
-          </Link>
+          <Link href={`/${locale}/games/wordle/solver`}>Solver</Link>
         </Button>
 
         <Button
@@ -166,7 +162,7 @@ export function WordleGame({ locale }: WordleGameProps) {
           size="sm"
           onClick={() => setShowKeyboard(!showKeyboard)}
           className="gap-2"
-          aria-label={showKeyboard ? "Hide keyboard" : "Show keyboard"}
+          aria-label={showKeyboard ? t("hideKeyboard") : t("showKeyboard")}
         >
           <Keyboard className="size-4" />
         </Button>
@@ -179,7 +175,6 @@ export function WordleGame({ locale }: WordleGameProps) {
           onKey={addLetter}
           onEnter={submitGuess}
           onBackspace={removeLetter}
-          locale={locale}
           disabled={gameState.gameStatus !== "playing"}
         />
       )}

--- a/components/wordle/wordle-keyboard.tsx
+++ b/components/wordle/wordle-keyboard.tsx
@@ -2,6 +2,7 @@
 
 import { cva } from "class-variance-authority";
 import { Delete } from "lucide-react";
+import { useLocale } from "next-intl";
 import { cn } from "@/lib/utils";
 import type { LetterState } from "@/lib/wordle/types";
 
@@ -50,7 +51,6 @@ interface WordleKeyboardProps {
   onKey: (key: string) => void;
   onEnter: () => void;
   onBackspace: () => void;
-  locale: string;
   disabled?: boolean;
 }
 
@@ -59,9 +59,9 @@ export function WordleKeyboard({
   onKey,
   onEnter,
   onBackspace,
-  locale,
   disabled = false,
 }: WordleKeyboardProps) {
+  const locale = useLocale();
   const keyboard = locale === "de" ? KEYBOARD_DE : KEYBOARD_EN;
   const isGerman = locale === "de";
 

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,158 @@
+# Implementation Plan
+
+Derived from the [Architecture Decision Records](adr/README.md) and [PLAN.md](PLAN.md). All work items reference the ADRs they must comply with.
+
+## Phase 1: Resolve Technical Debt
+
+Address the known inconsistencies documented in the ADRs before adding new features. This ensures the codebase is consistent and the ADR patterns are fully reliable as a guide.
+
+### 1.1 Standardize Wordle i18n (ADR-003, ADR-005)
+
+- Migrate all inline `locale === "de"` checks in Wordle components to `useTranslations()`
+- Add missing translation keys to `messages/en.json` and `messages/de.json` under the `games.wordle` namespace
+- Remove `locale` prop threading where `useTranslations()` replaces it
+- **Files:** `components/wordle/wordle-game.tsx`, `components/wordle/wordle-keyboard.tsx`, `messages/*.json`
+
+### 1.2 Standardize Pomodoro structure (ADR-005)
+
+- Extract state management from `pomodoro-app.tsx` into `components/pomodoro/use-pomodoro.ts` hook
+- Add barrel exports: `lib/pomodoro/index.ts` and `components/pomodoro/index.ts`
+- Align page component to pass `locale` prop like games do (or document the tools pattern as intentionally different)
+- **Files:** `components/pomodoro/pomodoro-app.tsx`, new `use-pomodoro.ts`, new `index.ts` files
+
+### 1.3 Standardize SiteNav dropdown (ADR-004, ADR-011)
+
+- Replace custom dropdown in `components/site-nav.tsx` with `components/ui/dropdown-menu.tsx` (Radix-based)
+- Maintain existing ARIA attributes and keyboard navigation
+- **Files:** `components/site-nav.tsx`
+
+### 1.4 Standardize back navigation (ADR-011)
+
+- Decide on a consistent pattern: either all feature pages have back links or none do
+- If back links: use `useTranslations("nav")` instead of hardcoded locale strings
+- Apply consistently across `app/[locale]/games/*/page.tsx` and `app/[locale]/tools/*/page.tsx`
+- **Files:** All feature page.tsx files
+
+### 1.5 Standardize storage validation (ADR-012)
+
+- Add runtime type guards to Wordle and Kniffel storage (follow Pomodoro's `storage.ts` pattern)
+- Extract storage functions from hooks into `lib/wordle/storage.ts` and `lib/kniffel/storage.ts`
+- **Files:** `components/wordle/use-wordle.ts`, `components/kniffel/use-kniffel.ts`, new storage modules
+
+### 1.6 Add tests to CI and clean up unused deps (ADR-007, ADR-008)
+
+- Add `bun run test` step to `.github/workflows/ci.yml` after lint and before build
+- Evaluate: either write component tests using `@testing-library/react` or remove unused dependencies (`@testing-library/react`, `@testing-library/dom`, `jsdom`)
+- If keeping component testing libraries, switch vitest environment to `jsdom` when needed
+- **Files:** `.github/workflows/ci.yml`, `package.json`, `vitest.config.ts`
+
+---
+
+## Phase 2: Planned Features
+
+### 2.1 Song Bingo Game (from PLAN.md)
+
+A Spotify-integrated music bingo game. Must follow all ADRs.
+
+**Architecture (per ADR-005):**
+- `lib/bingo/types.ts` — `BingoCard`, `BingoCell`, `GameState`, `SpotifyTrack`
+- `lib/bingo/game-logic.ts` — Card generation, win detection, shuffle algorithms
+- `lib/bingo/spotify.ts` — Spotify Web API client (track search, playback)
+- `lib/bingo/__tests__/game-logic.test.ts` — Pure function tests (ADR-007)
+- `components/bingo/use-bingo.ts` — Game state hook with localStorage persistence
+- `components/bingo/bingo-game.tsx` — Main orchestrator
+- `components/bingo/bingo-card.tsx`, `bingo-cell.tsx` — Presentation components
+- `components/bingo/index.ts` — Barrel exports
+- `app/[locale]/games/bingo/page.tsx` — Server component route
+
+**Authentication (from PLAN.md):**
+- Spotify OAuth via Next.js API routes (`app/api/spotify/`)
+- Tokens stored in HTTP-only cookies (not localStorage)
+- This is a new pattern not covered by existing ADRs — requires **ADR-013: Authentication** before implementation
+
+**i18n (per ADR-003):**
+- Add `games.bingo` namespace to `messages/en.json` and `messages/de.json`
+- All UI text via `useTranslations("games.bingo")`
+
+**Styling (per ADR-002):**
+- Use existing semantic tokens (card, primary, accent)
+- Dark mode support via CSS variables
+
+**Testing (per ADR-007):**
+- Unit tests for card generation and win detection in `lib/bingo/__tests__/`
+
+**New ADRs needed:**
+- ADR-013: Authentication (Spotify OAuth, cookie-based tokens, API routes)
+
+### 2.2 Blog Enhancements (from ADR-006)
+
+The blog is minimal. Planned improvements:
+
+- **Syntax highlighting**: Add rehype-pretty-code or similar remark/rehype plugin
+- **MDX components**: Extend `mdx-components.tsx` with styled `h2`, `h3`, `p`, `pre`, `code`, `blockquote`, `ul`, `ol`, `table`, `a`, `img`
+- **Blog features**: Reading time estimation, table of contents generation, related posts
+- **Content**: Write more posts in both EN and DE
+
+All changes must comply with ADR-002 (Tailwind styling, semantic tokens) and ADR-006 (MDX patterns).
+
+### 2.3 Future Tools
+
+Any new tool must follow the established four-layer architecture (ADR-005):
+
+```
+lib/{tool}/
+  types.ts
+  {logic}.ts
+  constants.ts
+  storage.ts          # Per ADR-012: runtime type guards, SSR-safe
+  index.ts            # Barrel export
+  __tests__/{logic}.test.ts  # Per ADR-007
+
+components/{tool}/
+  use-{tool}.ts       # Custom hook
+  {tool}-app.tsx      # Main orchestrator
+  {sub-components}.tsx
+  index.ts            # Barrel export
+
+app/[locale]/tools/{tool}/
+  page.tsx            # Server component
+
+messages/en.json      # Add {tool} namespace
+messages/de.json      # Add {tool} namespace (parity required)
+```
+
+---
+
+## Phase 3: Infrastructure
+
+### 3.1 PostgreSQL (from PLAN.md, ADR-009)
+
+Add when a feature requires shared/server-side state (e.g., multiplayer bingo, leaderboards):
+- Containerized PostgreSQL in the infra repo
+- Connection via Docker `web` network
+- One instance with multiple databases per app
+- Requires new ADR-014: Database Strategy
+
+### 3.2 Remote Dev Environment (from PLAN.md, ADR-009)
+
+- ttyd for web-based terminal access
+- Authelia for MFA protection
+- Caddy routing: `term.domain.com` → Authelia → ttyd
+- Requires new ADR-015: Remote Access
+
+---
+
+## ADR Compliance Checklist
+
+Use this checklist when implementing any new feature:
+
+- [ ] **ADR-001**: Uses Next.js App Router patterns (server components for pages, "use client" for interactivity)
+- [ ] **ADR-002**: Uses semantic color tokens from globals.css, supports dark mode, no hardcoded colors
+- [ ] **ADR-003**: All user-facing text in `messages/*.json`, uses `useTranslations()`, both EN and DE provided
+- [ ] **ADR-004**: Uses `components/ui/` primitives (Button, DropdownMenu), follows shadcn/ui patterns
+- [ ] **ADR-005**: Follows four-layer architecture (lib/ → hook → components → page)
+- [ ] **ADR-007**: Pure logic functions have unit tests in `lib/{feature}/__tests__/`
+- [ ] **ADR-008**: Passes `bun run check` (Biome lint) and `bun run build` (TypeScript)
+- [ ] **ADR-010**: Uses conventional commit format, jj workflow
+- [ ] **ADR-011**: Section index page updated with new feature card, consistent navigation
+- [ ] **ADR-012**: localStorage persistence with runtime type guards, SSR-safe, try/catch error handling

--- a/docs/adr/001-framework-and-runtime.md
+++ b/docs/adr/001-framework-and-runtime.md
@@ -1,0 +1,82 @@
+# ADR-001: Framework and Runtime
+
+**Status:** Accepted
+**Date:** 2026-02-06
+**Decision Makers:** Pascal Kraus
+
+## Context
+
+This personal website requires server-side rendering for SEO (blog content), rich client-side interactivity (games and tools), and first-class MDX support for content authoring. A modern, full-stack framework was needed that could handle all three concerns in a single codebase with strong TypeScript support and a streamlined developer experience.
+
+## Decision
+
+The project uses the following stack:
+
+- **Next.js ^16.1.6** with the **App Router** (not Pages Router) as the core framework (`next.config.ts:8-14`)
+- **React ^19.2.4** / **react-dom ^19.2.4** for the UI layer (`package.json:46-47`)
+- **TypeScript ^5.9.3** in strict mode with additional safety flags (`tsconfig.json:16-20`):
+  - `strict: true`, `noUncheckedIndexedAccess: true`, `noFallthroughCasesInSwitch: true`, `noImplicitOverride: true`
+  - Bundler module resolution (`tsconfig.json:11`)
+  - Incremental compilation enabled (`tsconfig.json:26`)
+- **bun** as both the package manager and production runtime (`Dockerfile:1` uses `oven/bun:1-alpine`, production runs `bun server.js` at `Dockerfile:44`)
+- **Output mode: `standalone`** for self-contained production builds (`next.config.ts:9`)
+- **Configuration flags** (`next.config.ts:10-12`):
+  - `reactStrictMode: true` for development quality checks
+  - `poweredByHeader: false` to remove the `X-Powered-By` header
+  - `compress: false` because compression is delegated to the Caddy reverse proxy
+- **Page extensions:** `ts`, `tsx`, `mdx` (`next.config.ts:13`)
+- **Plugins:** `next-intl/plugin` for internationalization and `@next/mdx` for MDX content (`next.config.ts:1-6, 16`)
+- **PostCSS:** `@tailwindcss/postcss` as the sole PostCSS plugin (`postcss.config.mjs:1-7`)
+- **Path aliases:** `@/*` maps to `./*` (`tsconfig.json:32-34`)
+- **Linting:** Biome ^2.3.13 (`package.json:16`) instead of ESLint/Prettier
+
+### Production Infrastructure
+
+The application is containerized with a multi-stage Docker build (`Dockerfile`):
+1. **deps** stage: installs dependencies with `bun install --frozen-lockfile`
+2. **builder** stage: runs `bun run build` to produce the standalone output
+3. **runner** stage: copies only `.next/standalone` and `.next/static`, runs as non-root `nextjs` user on port 3000
+
+Hosting is on Hetzner with Caddy as the reverse proxy handling HTTPS termination and compression.
+
+## Consequences
+
+### Positive
+- App Router provides React Server Components, streaming, and nested layouts out of the box
+- `standalone` output produces a self-contained deployment artifact (~50MB vs full node_modules)
+- bun provides faster installs, builds, and production startup compared to Node.js
+- Strict TypeScript catches entire classes of bugs at compile time (especially `noUncheckedIndexedAccess`)
+- MDX is a first-class page extension, enabling rich blog content with embedded components
+- Biome replaces both ESLint and Prettier with a single, fast tool
+
+### Negative
+- Next.js App Router is a more complex mental model than Pages Router (server vs. client components, async params)
+- bun runtime has a smaller ecosystem and fewer production battle-testing reports than Node.js
+- `standalone` output requires careful handling of static assets (manual copy in Dockerfile at line 35)
+- Cutting-edge versions (Next.js 16, React 19, TS 5.9) may encounter ecosystem compatibility gaps
+
+### Neutral
+- Caddy handles compression, so the Next.js compression middleware is explicitly disabled
+- The `poweredByHeader: false` flag is a minor security hardening measure
+- Incremental TypeScript compilation speeds up development but adds `.tsbuildinfo` files
+
+## Alternatives Considered
+
+| Alternative | Reason Not Chosen |
+|------------|-------------------|
+| Astro | Previously used; migrated away due to limited client-side interactivity support for games/tools |
+| Remix | Fewer MDX integrations, smaller plugin ecosystem at the time of decision |
+| SvelteKit | Would require learning Svelte; React ecosystem preferred for component libraries (shadcn/ui, Radix) |
+| Vite + React SPA | No SSR for blog SEO; would require separate SSG solution for content |
+| Node.js runtime | bun chosen for faster installs and startup; Alpine image keeps container small |
+| ESLint + Prettier | Biome provides both linting and formatting in a single tool with better performance |
+
+## References
+
+- `next.config.ts` — Framework configuration (plugins, output mode, flags)
+- `tsconfig.json` — TypeScript compiler options
+- `package.json` — Dependency versions and scripts
+- `postcss.config.mjs` — PostCSS plugin configuration
+- `Dockerfile` — Multi-stage production build
+- `app/layout.tsx` — Root layout (imports globals.css)
+- `app/[locale]/layout.tsx` — Locale layout (providers, html lang)

--- a/docs/adr/002-styling-and-theming.md
+++ b/docs/adr/002-styling-and-theming.md
@@ -1,0 +1,109 @@
+# ADR-002: Styling and Theming
+
+**Status:** Accepted
+**Date:** 2026-02-06
+**Decision Makers:** Pascal Kraus
+
+## Context
+
+The website needs a comprehensive styling system that supports light and dark themes, semantic design tokens, responsive design, and custom typography. The system must integrate cleanly with React Server Components and the shadcn/ui component pattern, while allowing per-theme personality (e.g., different monospace fonts in dark mode).
+
+## Decision
+
+### Tailwind CSS 4 (CSS-First Configuration)
+
+The project uses **Tailwind CSS ^4.1.18** with the new CSS-first configuration model (`app/globals.css:1`). There is no `tailwind.config.ts` file. All theme customization happens in CSS via `@theme inline { }` blocks.
+
+- **Entry point:** `@import "tailwindcss"` (`globals.css:1`)
+- **PostCSS integration:** `@tailwindcss/postcss` as the sole plugin (`postcss.config.mjs:3`)
+- **Theme registration:** `@theme inline { }` block at `globals.css:130-188` bridges CSS custom properties to Tailwind utility classes (e.g., `--color-primary: var(--primary)` enables `bg-primary`, `text-primary`, etc.)
+
+### Color System: oklch
+
+All color tokens use the **oklch** color space for perceptual uniformity. Colors are defined as CSS custom properties in `:root` (light) and `.dark` (dark) scopes:
+
+- **Light theme** (`globals.css:3-68`): Warm off-white background (`oklch(0.9914 0.0098 87.4695)`), green primary, blue secondary
+- **Dark theme** (`globals.css:70-128`): Warm dark background (`oklch(0.2225 0.0041 84.5879)`), all tokens have dark counterparts
+- **Semantic tokens:** `background`, `foreground`, `primary`, `secondary`, `accent`, `destructive`, `muted`, `card`, `popover`, `border`, `input`, `ring`, `chart-1` through `chart-5`, `sidebar-*`, `wordle-correct`, `wordle-present`
+
+### Theme Switching: next-themes
+
+- **Library:** `next-themes ^0.4.6` (`package.json:44`)
+- **Strategy:** `attribute="class"` — adds `"dark"` class to `<html>` element
+- **Defaults:** `defaultTheme="system"`, `enableSystem`, `disableTransitionOnChange`
+- **Provider:** `ThemeProvider` wraps the app inside `NextIntlClientProvider` (`app/[locale]/layout.tsx:27`)
+- **Toggle:** Client component with hydration-safe mounting using `useEffect` to avoid SSR mismatch, renders Sun/Moon icons from `lucide-react`
+
+### Typography
+
+Three font families are registered as CSS custom properties and bridged to Tailwind via `@theme inline`:
+
+| Token | Light Mode | Dark Mode |
+|-------|-----------|-----------|
+| `--font-sans` | Quicksand, system-ui, sans-serif | Quicksand, system-ui, sans-serif |
+| `--font-serif` | Lora, Georgia, serif | Lora, Georgia, serif |
+| `--font-mono` | Fira Code, monospace | Special Elite, ui-serif, serif |
+
+The dark mode monospace swap to **Special Elite** (`globals.css:107`) is an intentional design choice that gives dark mode a playful, typewriter aesthetic.
+
+### Shadow System
+
+Light and dark themes have distinctly different shadow aesthetics:
+
+- **Light** (`globals.css:42-65`): Subtle warm shadows with `0.08` opacity, `4px` y-offset, `12px` blur, using `hsl(27.27 10.48% 20.59%)`
+- **Dark** (`globals.css:109-127`): Dramatic shadows with `0.4` opacity, `8px` y-offset, `20px` blur, using pure black
+
+### Layout Tokens
+
+- **Spacing base:** `--spacing: 0.25rem` (`globals.css:67`)
+- **Border radius:** Base `--radius: 1rem`, computed variants via `calc()` at `globals.css:168-171` (`sm: -4px`, `md: -2px`, `lg: base`, `xl: +4px`)
+- **Letter spacing:** Base `--tracking-normal: 0.01em` with computed tighter/wider variants (`globals.css:182-187`)
+
+### Custom Animations
+
+Only one custom animation exists: `shake` for Wordle invalid guess feedback (`globals.css:197-214`).
+
+## Consequences
+
+### Positive
+- CSS-first Tailwind 4 config eliminates the JS config file and keeps all design tokens in one CSS file
+- oklch provides perceptually uniform color spacing — adjusting lightness/chroma is predictable
+- Semantic tokens (`primary`, `secondary`, etc.) decouple component styles from specific color values
+- `@theme inline` block makes all CSS variables available as Tailwind utilities (`bg-primary`, `text-muted-foreground`, etc.)
+- Per-theme typography gives each mode a distinct personality without extra complexity
+- `disableTransitionOnChange` prevents flash-of-wrong-theme during switches
+
+### Negative
+- oklch has limited browser DevTools support for visual color picking
+- The `@theme inline` bridge layer adds ~60 lines of boilerplate to map CSS vars to Tailwind tokens
+- Per-theme font changes (monospace) may surprise users who expect consistency across themes
+- No `@tailwindcss/typography` plugin (incompatible with Tailwind v4), so MDX prose styles must be manually applied
+
+### Neutral
+- Shadow definitions are verbose but provide complete control over per-theme shadow aesthetics
+- The `shake` animation is the only custom keyframe, keeping the animation surface area minimal
+- `suppressHydrationWarning` on `<html>` is required by next-themes to avoid SSR/client class mismatch
+
+## Alternatives Considered
+
+| Alternative | Reason Not Chosen |
+|------------|-------------------|
+| Tailwind v3 (JS config) | v4's CSS-first approach is cleaner and eliminates a config file |
+| CSS Modules | Less ergonomic for utility-first workflows; harder to share design tokens |
+| Styled Components | Runtime CSS-in-JS conflicts with React Server Components |
+| Vanilla CSS | No utility classes; slower iteration for responsive and state-based styling |
+| HSL color system | oklch is perceptually uniform; HSL has uneven perceived brightness across hues |
+| `@tailwindcss/typography` | Incompatible with Tailwind v4; MDX components styled directly instead |
+
+## References
+
+- `app/globals.css` — All theme tokens, color system, shadows, typography, and animations
+- `app/globals.css:1` — Tailwind 4 CSS import entry point
+- `app/globals.css:3-68` — Light theme tokens (`:root`)
+- `app/globals.css:70-128` — Dark theme tokens (`.dark`)
+- `app/globals.css:130-188` — `@theme inline` bridge to Tailwind utilities
+- `app/globals.css:197-214` — Custom `shake` animation
+- `postcss.config.mjs` — PostCSS configuration
+- `app/[locale]/layout.tsx:27` — ThemeProvider placement
+- `package.json:44` — next-themes version
+- `package.json:49` — Tailwind CSS version

--- a/docs/adr/003-internationalization.md
+++ b/docs/adr/003-internationalization.md
@@ -1,0 +1,105 @@
+# ADR-003: Internationalization
+
+**Status:** Accepted
+**Date:** 2026-02-06
+**Decision Makers:** Pascal Kraus
+
+## Context
+
+As a bilingual (English/German) personal website, all user-facing text must be available in both languages. The i18n solution needs to integrate deeply with the Next.js App Router (supporting both server and client components), handle locale-based routing, and provide a type-safe developer experience with minimal boilerplate.
+
+## Decision
+
+### Library: next-intl
+
+The project uses **next-intl ^4.8.1** (`package.json:42`), which provides first-class integration with Next.js App Router patterns including server components, middleware, and dynamic route segments.
+
+### Locale Configuration
+
+Locales are defined in `i18n/config.ts` with `as const` for TypeScript type safety:
+
+```typescript
+export const locales = ["en", "de"] as const;
+export const defaultLocale = "en" as const;
+export type Locale = (typeof locales)[number];
+```
+
+### Routing Strategy
+
+- **Locale prefix:** `"always"` — all routes include the locale segment (`/en/blog`, `/de/blog`) (`proxy.ts:7`)
+- **Dynamic segment:** `[locale]` in the app directory (`app/[locale]/layout.tsx`)
+- **Middleware:** `proxy.ts` (Next.js 16 pattern) using `createMiddleware` from `next-intl/middleware` (`proxy.ts:1-14`)
+  - Matcher: `["/", "/(en|de)/:path*"]` (`proxy.ts:12-13`)
+- **Locale validation:** The locale layout validates the segment against the `locales` array and calls `notFound()` for invalid locales (`app/[locale]/layout.tsx:17-19`)
+
+### Message Files
+
+- **Location:** `messages/en.json` and `messages/de.json` (perfect parity maintained between files)
+- **Loading:** Dynamic `import()` per locale in `i18n/request.ts:13` for code-splitting:
+  ```typescript
+  messages: (await import(`@/messages/${locale}.json`)).default
+  ```
+- **Provider:** `NextIntlClientProvider` wraps the app in the locale layout, passing all messages (`app/[locale]/layout.tsx:26`)
+
+### Message Structure
+
+- **Key naming:** camelCase, up to 4 levels deep
+- **Top-level namespaces:** `home`, `nav`, `games`, `tools`, `pomodoro`
+- **Nesting example:** `games.wordle.solver.controls.play`
+- **Interpolation:** ICU-style with `{word}`, `{number}`, `{count}`, `{minutes}`, `{percent}`, `{preset}`
+- **No ICU pluralization:** Uses simple `"{count} sessions"` pattern instead
+
+### Component Patterns
+
+| Pattern | Usage | Example |
+|---------|-------|---------|
+| Single namespace | Most components | `const t = useTranslations("nav")` |
+| Multiple namespaces | Complex components | `const tTimer = useTranslations("pomodoro.timer")` (tPrefix convention) |
+| Server-side | Async server components | `const t = await getTranslations("games")` |
+| Dot notation | Nested key access | `t("cta.prefix")` |
+| Locale-aware logic | Word list selection, routing | `const locale = useLocale()` |
+
+### Known Inconsistency
+
+The Wordle feature still uses inline locale checks (`locale === "de" ? "..." : "..."`) in some places instead of `useTranslations`. This predates the full i18n integration and should be migrated in a future cleanup pass.
+
+## Consequences
+
+### Positive
+- `localePrefix: "always"` makes every URL unambiguous about its language, aiding SEO and link sharing
+- Dynamic message imports ensure only the active locale's translations are loaded (code-split per locale)
+- `as const` locale definition provides compile-time type safety for locale values
+- Server-side `getTranslations` works in async server components without client-side overhead
+- `NextIntlClientProvider` makes translations available to all client components without prop drilling
+- next-intl's tight App Router integration handles server/client boundary transparently
+
+### Negative
+- `localePrefix: "always"` means bare `/blog` doesn't work — requires `/en/blog` (middleware redirects but adds a hop)
+- Two message files must be kept in perfect sync manually; no build-time check for missing keys
+- The Wordle inline locale check inconsistency creates a maintenance burden and inconsistent patterns
+- No ICU pluralization means some translations are grammatically simplified
+
+### Neutral
+- The `proxy.ts` naming convention is specific to Next.js 16's middleware pattern (previously `middleware.ts`)
+- Message files are ~174 lines each, manageable for a two-locale site
+- The tPrefix convention (`tTimer`, `tStats`) for multiple namespace hooks is a project-specific pattern
+
+## Alternatives Considered
+
+| Alternative | Reason Not Chosen |
+|------------|-------------------|
+| react-i18next | Less integrated with Next.js App Router; requires more manual setup for server components |
+| next-translate | Smaller ecosystem; less active maintenance compared to next-intl |
+| Manual locale props | No middleware support; would require prop drilling through entire component tree |
+| `localePrefix: "as-needed"` | Explicit locale in URL preferred for clarity and SEO; avoids ambiguity |
+| ICU MessageFormat pluralization | Added complexity not justified for a two-locale personal site with simple copy |
+
+## References
+
+- `i18n/config.ts` — Locale definitions and type export
+- `i18n/request.ts` — Message loading with dynamic imports
+- `proxy.ts` — Middleware configuration (locale detection, prefix strategy)
+- `app/[locale]/layout.tsx` — Locale validation, provider setup, html lang attribute
+- `messages/en.json` — English translations
+- `messages/de.json` — German translations
+- `package.json:42` — next-intl version

--- a/docs/adr/004-ui-component-architecture.md
+++ b/docs/adr/004-ui-component-architecture.md
@@ -1,0 +1,130 @@
+# ADR-004: UI Component Architecture
+
+**Status:** Accepted
+**Date:** 2026-02-06
+**Decision Makers:** Pascal Kraus
+
+## Context
+
+The website needs reusable, accessible UI components that integrate with the Tailwind-based design token system. The components must support theme variants, be fully owned by the project (not locked to a third-party component library's release cycle), and provide accessibility out of the box without manual ARIA management.
+
+## Decision
+
+### Pattern: shadcn/ui (Owned Components)
+
+The project follows the **shadcn/ui** pattern where components are copied into the project and owned by the codebase, rather than imported from a package. This means components live in `components/ui/` and can be freely modified.
+
+Currently, only **two** base UI components exist:
+
+1. **Button** (`components/ui/button.tsx`)
+2. **DropdownMenu** (`components/ui/dropdown-menu.tsx`)
+
+### Utility: cn()
+
+The standard shadcn/ui utility function is defined in `lib/utils.ts:4-6`:
+
+```typescript
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}
+```
+
+This combines `clsx` for conditional class composition with `tailwind-merge` for deduplication of conflicting Tailwind classes (e.g., `bg-red-500` + `bg-blue-500` resolves to the latter).
+
+### Button Component
+
+The Button (`components/ui/button.tsx`) uses **class-variance-authority (CVA)** for type-safe variant management:
+
+**Variants** (`button.tsx:11-22`):
+| Variant | Style |
+|---------|-------|
+| `default` | Primary background with white foreground |
+| `destructive` | Destructive color with dark mode opacity adjustment |
+| `outline` | Bordered with background, dark mode uses `input/30` |
+| `secondary` | Secondary background colors |
+| `ghost` | Transparent, hover reveals accent |
+| `link` | Text-only with underline on hover |
+
+**Sizes** (`button.tsx:24-32`):
+| Size | Dimensions |
+|------|-----------|
+| `default` | `h-9 px-4 py-2` |
+| `xs` | `h-6 px-2` with smaller text and icons |
+| `sm` | `h-8 px-3` |
+| `lg` | `h-10 px-6` |
+| `icon` | `size-9` (square) |
+| `icon-xs` | `size-6` |
+| `icon-sm` | `size-8` |
+| `icon-lg` | `size-10` |
+
+**Key features:**
+- Uses `@radix-ui/react-slot` (`button.tsx:1`) for polymorphism via the `asChild` prop (`button.tsx:45, 51`) — allows rendering as `<a>`, `<Link>`, or any other element while keeping button styling
+- Emits `data-slot="button"`, `data-variant`, and `data-size` attributes (`button.tsx:55-57`) for CSS targeting and testing
+- Built-in states: `focus-visible` ring, `aria-invalid` destructive ring, `disabled` opacity (`button.tsx:8`)
+- Automatic SVG sizing: `[&_svg:not([class*='size-'])]:size-4` (`button.tsx:8`)
+
+### DropdownMenu Component
+
+The DropdownMenu (`components/ui/dropdown-menu.tsx`) is a thin wrapper over `@radix-ui/react-dropdown-menu` that adds Tailwind styling to each Radix primitive:
+
+- **Re-exported primitives:** Root, Trigger, Group, Portal, Sub, RadioGroup (`dropdown-menu.tsx:9-19`)
+- **Styled wrappers:** SubTrigger, SubContent, Content, Item, CheckboxItem, RadioItem, Label, Separator, Shortcut (`dropdown-menu.tsx:21-205`)
+- **Portal rendering:** Content renders through `DropdownMenuPrimitive.Portal` (`dropdown-menu.tsx:65`) for proper z-index stacking
+- **Animations:** Uses Tailwind's `animate-in`/`animate-out` with directional slide-in classes based on `data-[side=*]` attributes (`dropdown-menu.tsx:70`)
+- **Accessibility:** Inherits full keyboard navigation, focus management, and ARIA attributes from Radix
+
+**Note:** The `SiteNav` component does **not** use this DropdownMenu component — it implements its own custom dropdown for navigation, which is an architectural inconsistency.
+
+### Icon System
+
+- **UI icons:** `lucide-react ^0.563.0` (`package.json:40`) — used for theme toggle (Sun/Moon), dropdown arrows (ChevronRight), indicators (Check, Circle)
+- **Social icons:** Custom inline SVGs (not from lucide) for GitHub, LinkedIn, etc.
+
+### Radix Primitives
+
+Two Radix packages are used:
+- `@radix-ui/react-dropdown-menu ^2.1.16` (`package.json:33`) — Full dropdown menu primitive
+- `@radix-ui/react-slot ^1.2.4` (`package.json:34`) — Polymorphic component composition (used in Button)
+
+## Consequences
+
+### Positive
+- Full ownership of component code — no waiting for upstream releases to fix bugs or add features
+- CVA provides compile-time variant type checking — invalid variant/size combinations are caught by TypeScript
+- Radix primitives provide WAI-ARIA compliant accessibility (keyboard navigation, screen reader support, focus trapping) without manual implementation
+- `cn()` utility prevents Tailwind class conflicts, enabling safe class composition and overrides
+- `data-slot` attributes enable CSS-based component targeting without fragile class selectors
+- The `asChild` pattern via Radix Slot enables flexible component composition (e.g., button-styled links)
+
+### Negative
+- Only 2 base components exist; new components must be manually added from shadcn/ui or built from scratch
+- The SiteNav dropdown inconsistency means two different dropdown implementations coexist
+- Radix adds ~20KB to the client bundle for dropdown functionality
+- CVA + clsx + tailwind-merge is three dependencies for class management (though each is small)
+
+### Neutral
+- The shadcn/ui pattern means components diverge from upstream over time (intentional — they're project-owned)
+- lucide-react provides a large icon set but only a handful are actually used
+- The DropdownMenu component includes RadioItem, CheckboxItem, and SubMenu variants that aren't currently used in the project
+
+## Alternatives Considered
+
+| Alternative | Reason Not Chosen |
+|------------|-------------------|
+| Headless UI | Less comprehensive primitive set than Radix; Tailwind Labs product but fewer components |
+| Ark UI | Newer ecosystem, less community adoption and documentation at time of decision |
+| MUI (Material UI) | Opinionated visual design; CSS-in-JS conflicts with React Server Components |
+| Ant Design | Heavy bundle size; visual style doesn't match the site's warm, personal aesthetic |
+| Fully custom components | Would require implementing accessibility (ARIA, keyboard nav, focus management) from scratch |
+| Tailwind Variants (tv) | CVA was already the shadcn/ui standard; switching would diverge from the established pattern |
+
+## References
+
+- `components/ui/button.tsx` — Button component with CVA variants
+- `components/ui/dropdown-menu.tsx` — DropdownMenu Radix wrapper
+- `lib/utils.ts` — `cn()` utility function
+- `package.json:33-34` — Radix UI dependencies
+- `package.json:37` — class-variance-authority
+- `package.json:38` — clsx
+- `package.json:48` — tailwind-merge
+- `package.json:40` — lucide-react icons

--- a/docs/adr/005-interactive-feature-architecture.md
+++ b/docs/adr/005-interactive-feature-architecture.md
@@ -1,0 +1,113 @@
+# ADR-005: Interactive Feature Architecture
+
+**Status:** Accepted
+**Date:** 2026-02-06
+**Decision Makers:** Pascal Kraus
+
+## Context
+
+The website hosts multiple interactive features — games (Wordle, Kniffel) and tools (Pomodoro timer) — each with substantial client-side logic, state management, persistence, and internationalization requirements. Without a consistent architecture, each feature would evolve independently, making the codebase harder to navigate, test, and extend. A shared structural pattern was needed to guide how interactive features are organized while keeping game/tool logic decoupled from React and the Next.js framework.
+
+## Decision
+
+All interactive features follow a **four-layer architecture** that separates pure logic from React state from UI rendering from routing:
+
+### Layer 1: Pure Logic — `lib/{feature}/`
+
+Framework-agnostic TypeScript modules containing types, constants, and pure functions:
+
+- `types.ts` — TypeScript interfaces, union types, and type constants
+- Domain logic modules — pure functions with no React imports (e.g., `lib/wordle/game-logic.ts`, `lib/kniffel/scoring.ts`, `lib/pomodoro/scheduler.ts`)
+- Data modules — constants, word lists, configuration values (e.g., `lib/pomodoro/constants.ts`, `lib/wordle/words-{locale}.ts`)
+- Barrel exports via `index.ts` for public API surface
+
+### Layer 2: React Bridge — `components/{feature}/use-{feature}.ts`
+
+A single custom hook per feature that bridges pure logic with React state:
+
+- Manages `useState`, `useEffect`, `useCallback`, `useMemo`
+- Handles localStorage persistence internally (lazy initialization, auto-save via `useEffect`)
+- Returns a state object and action handlers to the UI layer
+- Examples: `components/wordle/use-wordle.ts`, `components/kniffel/use-kniffel.ts`
+
+### Layer 3: UI Components — `components/{feature}/*.tsx`
+
+React components for rendering and interaction:
+
+- One main orchestrator component per feature (e.g., `components/wordle/wordle-game.tsx`, `components/pomodoro/pomodoro-app.tsx`)
+- Leaf presentation components for sub-sections (e.g., `components/pomodoro/stats-panel.tsx`, `components/pomodoro/sources-section.tsx`)
+- `"use client"` directive on all interactive components
+- Barrel exports via `index.ts` for clean imports from pages
+
+### Layer 4: Page Route — `app/[locale]/{category}/{feature}/page.tsx`
+
+Thin async server component that serves as the Next.js route entry point:
+
+- Calls `getTranslations()` for server-side i18n setup
+- Passes `locale` prop down to client components
+- Handles metadata generation (`generateMetadata`)
+
+### Current implementation status
+
+| Aspect | Wordle | Kniffel | Pomodoro |
+|--------|--------|---------|----------|
+| `lib/` barrel export | Yes (`lib/wordle/index.ts`) | Yes (`lib/kniffel/index.ts`) | No |
+| `components/` barrel export | Yes | Yes | No |
+| Custom hook | `use-wordle.ts` | `use-kniffel.ts` | None (state inline in `pomodoro-app.tsx`) |
+| i18n approach | Inline locale checks | Inline locale checks | `useTranslations()` hook |
+| Storage location | In hook file | In hook file | Separate `lib/pomodoro/storage.ts` |
+| Storage validation | Minimal (type cast) | Minimal (type cast) | Runtime type guards |
+| Sub-modules | `lib/wordle/solver/` | None | None |
+
+The Pomodoro timer deviates from the pattern in several ways (no barrel exports, no custom hook, separate storage module). These represent an evolution of the pattern — Pomodoro's storage validation via runtime type guards is more robust than the earlier features' approach, while its lack of a dedicated hook is a structural gap that could be addressed in future refactoring.
+
+### Common patterns across all features
+
+- **SSR guards**: `typeof window !== "undefined"` checks before accessing browser APIs
+- **Lazy `useState` from localStorage**: `useState(() => { /* read storage */ })` for hydration-safe initialization
+- **Auto-save via `useEffect`**: persist state changes to localStorage on every update
+- **Immutable state updates**: spread operators and `map`/`filter` for state transitions
+- **Constants extraction**: magic numbers and configuration values in dedicated constants files
+- **Pure function testing**: all testable logic lives in Layer 1, tested without mocks
+
+## Consequences
+
+### Positive
+- Pure logic in `lib/` is fully testable without React testing infrastructure — all ~107 tests run against pure functions
+- Features can be developed in parallel since each has an isolated directory structure
+- New developers can understand the pattern from any one feature and apply it to others
+- Layer 1 code could theoretically be reused outside React (CLI tools, other frameworks)
+- SSR compatibility is straightforward since server components never import client hooks
+
+### Negative
+- Some duplication of boilerplate across features (barrel exports, hook structure, page setup)
+- No shared abstractions for common patterns like localStorage persistence or game state machines
+- The Pomodoro timer's structural deviations create inconsistency until addressed
+- Each new feature requires creating files across 4 directories (`lib/`, `components/`, `app/`, `messages/`)
+
+### Neutral
+- The pattern emerged organically across three features rather than being designed upfront — each new feature refined it
+- No code generation or scaffolding tool exists for creating new features from this template
+- Feature-specific i18n approaches vary (inline locale checks vs. `useTranslations()`) reflecting different development timelines
+
+## Alternatives Considered
+
+| Alternative | Reason Not Chosen |
+|------------|-------------------|
+| Single-file components (all logic + UI in one file) | Prevents unit testing pure logic, creates large files, couples framework to domain logic |
+| Global state management (Redux, Zustand) | Overkill for independent features with no shared state; adds bundle size and conceptual overhead |
+| Server-side state (database-backed) | Features are client-only interactive tools; server state adds latency, complexity, and hosting requirements for no benefit |
+| Shared base hook / abstract game class | Premature abstraction — the three features have different enough state shapes that a generic abstraction would be leaky |
+| Feature-sliced design (FSD) | Over-structured for a personal site with 3 features; the simpler lib/components/app split provides sufficient separation |
+
+## References
+
+- `lib/wordle/` — Wordle pure logic (game-logic.ts, types.ts, solver/)
+- `lib/kniffel/` — Kniffel pure logic (scoring.ts, types.ts)
+- `lib/pomodoro/` — Pomodoro pure logic (scheduler.ts, constants.ts, storage.ts, notifications.ts, types.ts)
+- `components/wordle/use-wordle.ts` — Wordle React bridge hook
+- `components/kniffel/use-kniffel.ts` — Kniffel React bridge hook
+- `components/pomodoro/pomodoro-app.tsx` — Pomodoro main component (hook logic inline)
+- `app/[locale]/games/wordle/page.tsx` — Wordle route
+- `app/[locale]/games/kniffel/page.tsx` — Kniffel route
+- `app/[locale]/tools/pomodoro/page.tsx` — Pomodoro route

--- a/docs/adr/006-content-management.md
+++ b/docs/adr/006-content-management.md
@@ -1,0 +1,126 @@
+# ADR-006: Content Management
+
+**Status:** Accepted
+**Date:** 2026-02-06
+**Decision Makers:** Pascal Kraus
+
+## Context
+
+The website includes a personal blog that requires authoring rich content (text, code snippets, and potentially embedded React components) in two languages (English and German). A content management approach was needed that supports bilingual content, integrates naturally with the Next.js App Router, allows version-controlled authoring, and keeps the setup minimal for a personal site without requiring external services or databases.
+
+## Decision
+
+Blog content is managed as **local MDX files** processed at build time and rendered via server-side MDX compilation. The system has three layers: content files, a loading library, and rendering pages.
+
+### Content Storage
+
+MDX files are stored in the repository organized by locale:
+
+```
+content/
+  en/
+    hello-world.mdx
+  de/
+    hello-world.mdx
+```
+
+Each file uses YAML frontmatter with the following schema:
+
+```yaml
+title: "Post Title"          # Required — displayed in listings and page
+date: "YYYY-MM-DD"           # Required — used for sorting and display
+description: "Summary text"  # Required — shown in blog index
+translationKey: "post-id"    # Optional — links equivalent posts across locales
+```
+
+The `PostMeta` TypeScript interface in `lib/posts.ts` mirrors this structure:
+
+```typescript
+interface PostMeta {
+  slug: string;
+  title: string;
+  date: string;
+  description: string;
+  translationKey?: string;
+}
+```
+
+### Content Loading — `lib/posts.ts`
+
+Three server-only functions use Node.js `fs` and `gray-matter` to load content:
+
+- **`getPostSlugs(locale)`** — reads `content/{locale}/`, filters `.mdx` files, strips extensions to produce slug list
+- **`getPostBySlug(locale, slug)`** — reads a single file, parses frontmatter with `gray-matter`, returns `{ meta: PostMeta, content: string }`
+- **`getAllPosts(locale)`** — loads all posts for a locale, returns them sorted by date descending
+
+### MDX Rendering
+
+- **Blog index** (`app/[locale]/blog/page.tsx`) — server component that calls `getAllPosts(locale)` and renders a list of `Link` elements with title, date, and description
+- **Blog post** (`app/[locale]/blog/[slug]/page.tsx`) — server component that renders individual posts using `MDXRemote` from `next-mdx-remote/rsc` for server-side MDX compilation
+- **Static generation** — `generateStaticParams()` pre-renders all locale + slug combinations at build time
+- **404 handling** — `notFound()` is called for missing slugs
+
+### MDX Component Customization
+
+Custom component mapping is defined in `mdx-components.tsx` at the project root. Currently minimal — only `h1` is styled with Tailwind classes. The `@tailwindcss/typography` plugin is deliberately not used due to incompatibility with Tailwind v4.
+
+### Dependencies
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `@next/mdx` | ^16.1.6 | Next.js MDX integration |
+| `@mdx-js/loader` | ^3.1.1 | Webpack loader for MDX files |
+| `@mdx-js/react` | ^3.1.0 | React context provider for MDX components |
+| `next-mdx-remote` | ^5.0.0 | Server-side MDX compilation (`MDXRemote` from `/rsc`) |
+| `gray-matter` | ^4.0.3 | YAML frontmatter parsing |
+
+### What is NOT configured
+
+- No remark or rehype plugins (no syntax highlighting, no GFM extensions, no auto-linking)
+- No table of contents generation
+- No reading time estimation
+- No RSS feed generation
+- No draft/published status field
+- No tags or categories
+
+## Consequences
+
+### Positive
+- Content is version-controlled alongside code — PRs for blog posts get the same review workflow
+- No external service dependencies — no CMS accounts, API keys, or network calls at build time
+- MDX allows embedding React components directly in posts when needed (e.g., interactive demos)
+- Bilingual content is cleanly separated by locale directory with optional cross-linking via `translationKey`
+- Server-side rendering via `next-mdx-remote/rsc` means zero client-side JavaScript for blog post content
+- Build-time static generation produces fast, cacheable HTML pages
+
+### Negative
+- Adding a post requires a code commit and deployment — no web-based editing UI
+- No built-in content search, tagging, or filtering capabilities
+- Manual frontmatter management with no validation beyond TypeScript types (no Zod schema, no build-time checks)
+- The `translationKey` cross-linking mechanism exists in the type but has no UI implementation yet
+- Content and code are coupled in the same repository, which may not scale for high-volume blogging
+
+### Neutral
+- Currently only one post exists (`hello-world`) in both locales — the system is designed for growth but lightly exercised
+- No syntax highlighting means code blocks render as plain styled text
+- The `@tailwindcss/typography` incompatibility with Tailwind v4 means all MDX element styles must be manually defined in `mdx-components.tsx`
+
+## Alternatives Considered
+
+| Alternative | Reason Not Chosen |
+|------------|-------------------|
+| Headless CMS (Contentful, Sanity, Strapi) | Adds external dependency, API complexity, and cost for a personal blog with minimal content; overkill for current scale |
+| Plain Markdown without MDX | Loses ability to embed React components in posts; MDX is a superset with no downside for simple content |
+| Notion API as content source | Ties content to a proprietary platform, adds runtime API dependency, requires mapping Notion blocks to React components |
+| Database-backed CMS (WordPress, Ghost) | Requires separate hosting, database management, and a different tech stack; doesn't integrate with the existing Next.js setup |
+| Content collections (Astro-style) | Not natively supported by Next.js; would require custom build tooling or switching frameworks |
+
+## References
+
+- `content/en/hello-world.mdx` — Example English blog post
+- `content/de/hello-world.mdx` — Example German blog post
+- `lib/posts.ts` — Content loading functions (`getPostSlugs`, `getPostBySlug`, `getAllPosts`)
+- `app/[locale]/blog/page.tsx` — Blog index page (server component)
+- `app/[locale]/blog/[slug]/page.tsx` — Blog post page (server component with MDXRemote)
+- `mdx-components.tsx` — Custom MDX component styling
+- `next.config.ts` — MDX plugin configuration

--- a/docs/adr/007-testing-strategy.md
+++ b/docs/adr/007-testing-strategy.md
@@ -1,0 +1,143 @@
+# ADR-007: Testing Strategy
+
+**Status:** Accepted
+**Date:** 2026-02-06
+**Decision Makers:** Pascal Kraus
+
+## Context
+
+The website contains interactive features (Wordle, Kniffel, Pomodoro) with non-trivial pure logic — game rules, scoring algorithms, scheduling calculations, and solver heuristics. This logic needs automated testing to catch regressions, but the project is a personal site where heavy test infrastructure (browser automation, component rendering, visual regression) would add disproportionate maintenance overhead. A testing strategy was needed that provides high confidence in correctness for the logic that matters most, without slowing down development.
+
+## Decision
+
+Adopt a **pure-function unit testing** strategy using Vitest, testing only the framework-agnostic logic layer (`lib/`) with no mocking, no DOM rendering, and no component tests.
+
+### Framework and Configuration
+
+**Vitest** (^4.0.18) is the test runner, configured in `vitest.config.ts`:
+
+```typescript
+{
+  test: {
+    environment: "node",              // No jsdom — tests run in Node.js
+    include: ["**/*.test.ts", "**/*.test.tsx"],
+    exclude: ["node_modules", ".next"]
+  },
+  resolve: {
+    alias: { "@": path.resolve(__dirname) }  // Matches tsconfig paths
+  }
+}
+```
+
+Key configuration choices:
+- **Node environment** — no browser simulation needed since all tested code is pure TypeScript
+- **Path alias** — `@/` resolves to project root, matching the app's `tsconfig.json` paths
+- **No coverage threshold** — coverage is not configured or enforced
+
+### Test Organization
+
+Tests live alongside the code they test using the `__tests__` directory convention:
+
+```
+lib/
+  wordle/
+    __tests__/
+      game-logic.test.ts     # ~16 tests, 160 lines
+    solver/
+      __tests__/
+        solver.test.ts       # ~18 tests, 227 lines
+  kniffel/
+    __tests__/
+      scoring.test.ts        # ~32 tests, 442 lines
+  pomodoro/
+    __tests__/
+      scheduler.test.ts      # ~41 tests, 430 lines
+```
+
+Total: **4 test files, ~107 tests** covering all three features' core logic.
+
+### Test Style
+
+All tests follow consistent patterns:
+
+- **Explicit imports**: `import { describe, expect, it } from "vitest"` — no globals
+- **Describe/it blocks**: grouped by function or behavior area
+- **No mocking**: zero usage of `vi.mock()`, `vi.fn()`, or `vi.spyOn()` — all inputs are constructed directly
+- **Local helper functions**: test-specific factories like `createDice()`, `createPlayer()`, `makeDate()` for readable test setup
+- **No data-driven tests**: `it.each()` is not used; each test case is explicit
+- **Assertions**: `toBe`, `toEqual`, `toBeGreaterThan`, `toBeCloseTo`, `toHaveLength`, `toContain`, `not.toBeNull`, `toThrow`
+
+### What is tested
+
+| Feature | Module | What's Tested |
+|---------|--------|---------------|
+| Wordle | `game-logic.ts` | Letter evaluation, game state transitions, win/loss detection |
+| Wordle | `solver/` | Word filtering, hint generation, candidate scoring |
+| Kniffel | `scoring.ts` | All 13 Yahtzee category calculations, bonus logic, upper section scoring |
+| Pomodoro | `scheduler.ts` | Schedule generation, break ratios, fatigue algorithm, time-based scheduling, preset suggestions |
+
+### What is NOT tested
+
+- **React components** — no component rendering tests despite `@testing-library/react` and `jsdom` being installed as dependencies
+- **Hooks** — custom hooks (`use-wordle.ts`, `use-kniffel.ts`) are not tested
+- **Integration** — no tests for page rendering, routing, or i18n
+- **E2E** — no browser automation (Playwright, Cypress)
+- **Visual** — no screenshot comparison or Storybook
+- **API** — no route handler tests (none exist currently)
+
+### CI Integration
+
+Tests are **not run in CI**. The CI pipeline (`bun run check` + `bun run build`) enforces linting and type-checking only. Tests are run locally by developers via:
+
+```bash
+bun run test        # Single run (vitest run)
+bun run test:watch  # Watch mode (vitest)
+```
+
+### Scripts
+
+| Script | Command | Purpose |
+|--------|---------|---------|
+| `test` | `vitest run` | Run all tests once |
+| `test:watch` | `vitest` | Run in watch mode for development |
+
+## Consequences
+
+### Positive
+- Tests are extremely fast — Node.js environment with pure functions, no DOM overhead, completing in under a second
+- Zero mocking means tests verify real behavior, not mock configurations
+- The pure logic separation (ADR-005) makes testing natural — functions take inputs and return outputs
+- Low maintenance burden — no flaky browser tests, no snapshot updates, no mock version drift
+- Adding tests for new features follows an obvious pattern: create `lib/{feature}/__tests__/{module}.test.ts`
+
+### Negative
+- No coverage of React component behavior — UI bugs (wrong props, broken event handlers, rendering issues) are only caught manually
+- Custom hooks contain significant logic (localStorage persistence, state coordination) that has no automated verification
+- Tests not running in CI means regressions can be merged if a developer forgets to run tests locally
+- `@testing-library/react` and `jsdom` are installed but unused, adding unnecessary dependencies
+- No integration testing means cross-layer issues (e.g., wrong prop types between components) rely solely on TypeScript
+
+### Neutral
+- The testing strategy aligns with the project's scope as a personal site — comprehensive testing would be warranted for a team or production SaaS product
+- Test count (~107) is substantial for the amount of logic, suggesting good coverage of the pure layer
+- The absence of `it.each` data-driven tests is a style choice — it makes tests more verbose but also more readable
+
+## Alternatives Considered
+
+| Alternative | Reason Not Chosen |
+|------------|-------------------|
+| Jest | Vitest is faster, has native ESM support, compatible config with Vite/Next.js, and the team is already using it |
+| React Testing Library component tests | Adds DOM simulation overhead (`jsdom`), requires maintaining component test fixtures, and the pure logic layer captures the most important behavior |
+| Playwright or Cypress E2E | Heavy infrastructure for a personal site; browser tests are slow, flaky, and require maintenance as UI changes |
+| Storybook visual regression | Significant setup overhead (Storybook config, screenshot infrastructure); overkill for the current number of components |
+| No tests at all | Game logic and scheduling algorithms have enough complexity that manual testing alone would miss edge cases |
+| Test coverage enforcement | Adds friction without proportional benefit for a personal project; the focus is on testing important logic, not hitting arbitrary coverage numbers |
+
+## References
+
+- `vitest.config.ts` — Test runner configuration
+- `lib/wordle/__tests__/game-logic.test.ts` — Wordle game logic tests
+- `lib/wordle/solver/__tests__/solver.test.ts` — Wordle solver tests
+- `lib/kniffel/__tests__/scoring.test.ts` — Kniffel scoring tests
+- `lib/pomodoro/__tests__/scheduler.test.ts` — Pomodoro scheduler tests
+- `package.json` — Test scripts (`test`, `test:watch`)

--- a/docs/adr/008-code-quality-and-linting.md
+++ b/docs/adr/008-code-quality-and-linting.md
@@ -1,0 +1,152 @@
+# ADR-008: Code Quality and Linting
+
+**Status:** Accepted
+**Date:** 2026-02-06
+**Decision Makers:** Pascal Kraus
+
+## Context
+
+The project needed automated code quality enforcement for consistent formatting, linting, and import organization across TypeScript, CSS, and configuration files. The JavaScript ecosystem traditionally requires multiple tools for this (ESLint for linting, Prettier for formatting, import-sort plugins), each with their own configuration files, plugin ecosystems, and sometimes conflicting rules. A unified, fast solution was needed to avoid configuration sprawl and tooling conflicts.
+
+## Decision
+
+Use **Biome** (^2.3.13) as the single tool for linting, formatting, and import organization — replacing ESLint, Prettier, and any import sorting plugins entirely.
+
+### Configuration — `biome.json`
+
+```json
+{
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true           // Respects .gitignore
+  },
+  "files": {
+    "include": ["**"],
+    "ignoreUnknown": true           // Silently skip non-supported file types
+  },
+  "formatter": {
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",       // Double quotes everywhere
+      "semicolons": "always"        // Always use semicolons
+    }
+  },
+  "css": {
+    "formatter": {
+      "indentWidth": 2
+    }
+  },
+  "linter": {
+    "rules": {
+      "recommended": true           // All recommended rules, no custom overrides
+    }
+  },
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": {
+          "level": "on"             // Auto-sort imports
+        }
+      }
+    }
+  },
+  "css": {
+    "linter": { "enabled": true },
+    "parser": {
+      "cssModules": "allow",
+      "allowSuperAtRuleParams": true  // Support Tailwind directives like @theme
+    }
+  }
+}
+```
+
+Key configuration choices:
+- **Recommended rules only** — no custom rule overrides, keeping the config minimal and aligned with community standards
+- **Git-aware** — uses `.gitignore` to skip `node_modules/`, `.next/`, `bun.lock`, and other generated files
+- **CSS support** — lints CSS files with CSS modules and Tailwind directive compatibility
+- **Import organization** — automatically sorts and groups imports as a source action
+
+### Excluded Files
+
+Via `.gitignore` integration: `node_modules/`, `.next/`, `bun.lock`
+
+### Scripts
+
+| Script | Command | Purpose |
+|--------|---------|---------|
+| `check` | `biome check .` | Lint + format check (read-only, fails on issues) |
+| `fix` | `biome check . --write` | Auto-fix all fixable issues |
+
+The `make check` target chains linting with the production build: `bun run check && bun run build`.
+
+### Enforcement Pipeline
+
+**Local development:**
+1. `bun run check` — read-only validation (CI-equivalent)
+2. `bun run fix` — auto-fix formatting and import ordering
+3. IDE integration — Biome LSP provides real-time feedback
+
+**CI (GitHub Actions):**
+1. `bun run check` — lint and format validation
+2. `bun run build` — TypeScript type-checking via Next.js production build
+
+TypeScript **strict mode** acts as an additional quality gate — the production build fails on type errors, complementing Biome's JavaScript/TypeScript linting.
+
+### What Biome replaces
+
+| Previous Tool | Biome Equivalent |
+|--------------|-----------------|
+| ESLint | `linter` section — static analysis rules |
+| Prettier | `formatter` section — code formatting |
+| eslint-plugin-import / import-sort | `assist.actions.source.organizeImports` |
+| .editorconfig | `formatter` section (indent style/width) |
+
+### What Biome does NOT cover
+
+- **TypeScript type checking** — handled by the `tsc` step in `bun run build`
+- **Test execution** — handled by Vitest (see ADR-007)
+- **Commit hooks** — no pre-commit hooks are configured (no husky, lint-staged)
+- **Spell checking** — not configured
+
+## Consequences
+
+### Positive
+- Single configuration file (`biome.json`) replaces 2-3 separate config files (`.eslintrc`, `.prettierrc`, `.editorconfig`)
+- Extremely fast — Biome processes all 95+ project files in ~23ms, written in Rust
+- No plugin compatibility issues — ESLint + Prettier integration is a common source of conflicts that Biome eliminates entirely
+- Zero custom rule overrides means the project benefits from community-maintained defaults without config drift
+- CSS linting with Tailwind directive support catches CSS issues that ESLint alone would miss
+- Import organization is automatic — no manual import sorting or plugin configuration
+
+### Negative
+- Biome's rule set is smaller than ESLint's ecosystem — some specialized rules (React hooks exhaustive-deps, accessibility) may not have equivalents
+- Less mature ecosystem compared to ESLint — fewer community plugins, less Stack Overflow coverage
+- Migrating to or from Biome requires config translation if the tooling choice changes
+- No pre-commit hooks means developers can commit code that fails `bun run check` — CI catches it, but the feedback loop is slower
+
+### Neutral
+- Biome's formatting opinions (double quotes, always semicolons) match the project's chosen style — these are configuration choices, not constraints
+- The `ignoreUnknown: true` setting means Biome silently skips files it doesn't understand rather than erroring, which could mask misconfiguration
+- Tests are not included in the CI quality gate (only lint + build) — this is a separate decision documented in ADR-007
+
+## Alternatives Considered
+
+| Alternative | Reason Not Chosen |
+|------------|-------------------|
+| ESLint + Prettier | Two tools with separate configs, plugin compatibility issues (eslint-config-prettier), slower execution, and more complex setup |
+| ESLint flat config (v9+) | Improved ESLint config but still requires Prettier for formatting; doesn't solve the multi-tool problem |
+| deno lint | Tied to the Deno ecosystem; less natural integration with Next.js and bun |
+| oxlint | Fast Rust-based linter but formatting-only via separate tool (oxc_formatter); less mature than Biome at the time of adoption |
+| Rome (Biome's predecessor) | Project was abandoned; Biome is the community fork and active successor |
+| No linter (TypeScript only) | TypeScript catches type errors but not style issues, unused variables behind type assertions, import ordering, or formatting consistency |
+
+## References
+
+- `biome.json` — Biome configuration
+- `package.json` — Scripts (`check`, `fix`)
+- `Makefile` — `make check` target (lint + build)
+- `.github/workflows/` — CI configuration running `bun run check` + `bun run build`

--- a/docs/adr/009-infrastructure-and-deployment.md
+++ b/docs/adr/009-infrastructure-and-deployment.md
@@ -1,0 +1,102 @@
+# ADR-009: Infrastructure and Deployment
+
+**Status:** Accepted
+**Date:** 2026-02-06
+**Decision Makers:** Pascal Kraus
+
+## Context
+
+The personal website needs reliable, cost-effective hosting with full control over the deployment pipeline. As a developer-focused personal site, vendor lock-in to platform-as-a-service providers was undesirable — the infrastructure itself serves as a learning platform and should support multiple applications beyond just this website. The deployment model needed to be simple enough for a single maintainer while supporting both development and production environments.
+
+## Decision
+
+### Hosting and Server
+
+The site is self-hosted on a **Hetzner** dedicated server with a **self-hosted GitHub Actions runner** for CI/CD execution. This provides full root access, predictable pricing, and no usage-based billing surprises.
+
+### Container Architecture
+
+The application uses a **multi-stage Docker build** (`Dockerfile`) based on `oven/bun:1-alpine`:
+
+1. **base** stage: `oven/bun:1-alpine` base image
+2. **deps** stage: installs dependencies with `bun install --frozen-lockfile`
+3. **builder** stage: copies source files and `node_modules`, runs `bun run build` to produce standalone output
+4. **runner** stage: copies only `.next/standalone` and `.next/static`, runs as a non-root user (`nextjs:1001` / `nodejs:1001` group) on port 3000 with `NODE_ENV=production` and `HOSTNAME=0.0.0.0`
+
+The final command is `bun server.js`, using bun as the production runtime.
+
+### Docker Compose
+
+Two compose files manage environments:
+
+- **`docker-compose.dev.yml`** — container named `website-dev`
+- **`docker-compose.prod.yml`** — container named `website-prod`
+
+Both are nearly identical: `restart: unless-stopped`, connected to an external `web` Docker network, `NODE_ENV=production`. Neither file exposes port mappings — applications are only accessible through the shared `web` network via the reverse proxy.
+
+### Reverse Proxy
+
+**Caddy** runs in a separate infrastructure repository as its own container, handling:
+
+- HTTPS termination (ports 80/443 with automatic certificate management)
+- HTTP compression (the app explicitly disables compression via `compress: false` in `next.config.ts:12`)
+- Request routing to backend containers over the shared `web` network
+
+### Network Architecture
+
+An **external Docker network `web`** is shared between Caddy and all application containers. Each application repository contains its own `docker-compose.yml` that joins this network. The infrastructure repository manages Caddy and shared services. This multi-app architecture allows adding new applications (future PostgreSQL, ttyd, Authelia) by simply joining the same network.
+
+### CI/CD Pipeline
+
+Three GitHub Actions workflows:
+
+- **`ci.yml`**: Runs on PRs and pushes to main — checkout → setup bun → install → `bun run check` → `bun run build`. Note: does not run tests.
+- **`deploy-dev.yml`**: Manual `workflow_dispatch` trigger — runs on self-hosted runner → `docker compose build` → `docker compose up -d` → `docker image prune`
+- **`deploy-production.yml`**: Triggered by GitHub release publish events — runs on self-hosted runner → `docker compose build` → `docker compose up -d` → `docker image prune`
+
+Deployments are intentionally manual (dev) or release-gated (production) rather than continuous, providing a deliberate checkpoint before changes reach each environment.
+
+## Consequences
+
+### Positive
+- Full control over the server, network, and deployment pipeline with zero vendor lock-in
+- Predictable monthly cost regardless of traffic spikes (no usage-based billing)
+- Multi-stage Docker build produces a minimal production image (~50MB standalone output)
+- Non-root container user follows security best practices
+- Caddy's automatic HTTPS eliminates certificate management overhead
+- The shared `web` network pattern scales to multiple applications trivially
+- Self-hosted runner enables deployment without exposing SSH credentials in CI
+
+### Negative
+- Single server is a single point of failure (no redundancy or auto-scaling)
+- Self-hosted runner requires server maintenance and security updates
+- No automated rollback mechanism — failed deployments require manual intervention
+- CI pipeline does not run tests, relying on local testing discipline
+- Two nearly-identical compose files (`dev` and `prod`) differ only in container name, creating minor duplication
+
+### Neutral
+- Compression is delegated entirely to Caddy, so the Next.js compression middleware is disabled
+- The `docker image prune` step in deploy workflows keeps disk usage manageable
+- Future services (PostgreSQL, Authelia) can join the `web` network without modifying existing containers
+
+## Alternatives Considered
+
+| Alternative | Reason Not Chosen |
+|------------|-------------------|
+| Vercel | Vendor lock-in, usage-based pricing at scale, limited control over infrastructure |
+| Netlify | Similar vendor lock-in concerns; less suitable for server-rendered Next.js with standalone output |
+| Railway / Render | Abstraction layer over containers removes learning opportunity; cost scales with usage |
+| AWS / GCP | Complexity overkill for a personal site; requires significant DevOps knowledge for comparable setup |
+| Bare metal without containers | Harder to reproduce environments, no isolation between applications, manual dependency management |
+| Nginx reverse proxy | Caddy chosen for automatic HTTPS and simpler configuration syntax |
+| Continuous deployment (auto-deploy on push) | Deliberate deployment gates preferred for a single-maintainer project |
+
+## References
+
+- `Dockerfile` — Multi-stage build definition (base, deps, builder, runner stages)
+- `docker-compose.dev.yml` — Development environment compose configuration
+- `docker-compose.prod.yml` — Production environment compose configuration
+- `next.config.ts:12` — `compress: false` delegating to Caddy
+- `.github/workflows/ci.yml` — CI pipeline (lint + build)
+- `.github/workflows/deploy-dev.yml` — Development deployment workflow
+- `.github/workflows/deploy-production.yml` — Production deployment workflow

--- a/docs/adr/010-version-control.md
+++ b/docs/adr/010-version-control.md
@@ -1,0 +1,105 @@
+# ADR-010: Version Control
+
+**Status:** Accepted
+**Date:** 2026-02-06
+**Decision Makers:** Pascal Kraus
+
+## Context
+
+The project needed a version control system that integrates with GitHub for pull requests and collaboration while providing a better developer experience than raw Git for day-to-day operations. Common Git pain points — the staging area, destructive rebases, complex history editing — motivated evaluating modern alternatives that maintain full Git compatibility.
+
+## Decision
+
+The project uses **Jujutsu (jj)** as the primary version control system in a **colocated workspace** where both `.jj/` and `.git/` directories exist side by side. This provides Git compatibility for GitHub integration while using jj's improved interface for all local operations.
+
+### Why Jujutsu
+
+- **No staging area**: changes auto-track, eliminating the `git add` step entirely
+- **Working copy is a commit**: the working directory is always a valid commit, providing a simpler mental model
+- **Automatic rebasing of descendants**: editing any commit in the history automatically rebases all descendant commits
+- **Conflict propagation**: conflicts are recorded in commits and can be resolved once, with the fix propagating downstream
+- **Operation log with full undo**: every operation is recorded and undoable via `jj undo`, making history editing safe
+- **Bookmarks instead of branches**: jj "bookmarks" map directly to Git branches when pushing
+
+### Conventions
+
+**Branch/bookmark naming** follows a prefix convention:
+- `feature/` — new features
+- `fix/` — bug fixes
+- `chore/` — maintenance tasks
+- `docs/` — documentation changes
+- `refactor/` — code restructuring
+- `test/` — test additions/changes
+- `perf/` — performance improvements
+
+**Commit message format**: `type: description` using the same type prefixes (e.g., `feat: add pomodoro timer`, `fix: mobile header alignment`).
+
+### PR Workflow
+
+```
+jj describe -m "feat: description"           # Describe current change
+jj bookmark create feature/name              # Create bookmark (Git branch)
+jj bookmark track feature/name --remote=origin
+jj git push --bookmark feature/name          # Push to GitHub
+gh pr create --head feature/name --base master
+```
+
+### Syncing with upstream
+
+```
+jj git fetch && jj rebase -d master
+```
+
+### Makefile Integration
+
+The `Makefile` provides convenience targets:
+- `make jj-push BOOKMARK=name` — push a specific bookmark
+- `make jj-status` — check current status
+- `make jj-log` — view history
+
+### User Preferences
+
+Enforced via `CLAUDE.md` project instructions:
+- Never auto-commit or auto-push — all commits and pushes are explicit user actions
+- Always use `jj` commands instead of native `git` commands
+- User identity only on all commits (no AI co-author attribution)
+
+A comprehensive reference document exists at `docs/JJ_REFERENCE.md` covering all common operations.
+
+## Consequences
+
+### Positive
+- Auto-tracking eliminates forgotten unstaged files — every change is always part of a commit
+- Safe history editing via operation log removes the fear of `git rebase` destroying work
+- Conflict propagation makes multi-commit rebases significantly less painful
+- Full Git compatibility means GitHub PRs, Actions, and tooling work without modification
+- The colocated workspace allows falling back to `git` commands if needed (though this is discouraged)
+
+### Negative
+- Jujutsu is a relatively new tool with a smaller community and fewer resources than Git
+- Team members or contributors unfamiliar with jj face a learning curve
+- Some Git-specific tooling (IDE integrations, GUI clients) may not fully support jj
+- The colocated `.jj/` + `.git/` workspace uses slightly more disk space
+- AI coding assistants default to Git commands and must be explicitly instructed to use jj
+
+### Neutral
+- The `.jj/` directory is gitignored and does not affect the repository for Git-only users
+- Bookmarks and Git branches are conceptually equivalent — the mental model maps cleanly
+- The Makefile targets provide a convenience layer but are not required for any workflow
+
+## Alternatives Considered
+
+| Alternative | Reason Not Chosen |
+|------------|-------------------|
+| Plain Git | Staging area friction, destructive rebases, no operation log for safe undo |
+| Sapling (Meta) | Less mature Git interop at evaluation time; smaller community than jj |
+| Pijul | Patch-based model is interesting but limited Git compatibility and ecosystem |
+| Fossil | Built-in wiki/tickets not needed; weaker GitHub integration |
+| Git with aliases/scripts | Addresses symptoms but not root causes (mental model complexity, conflict handling) |
+
+## References
+
+- `docs/JJ_REFERENCE.md` — Comprehensive Jujutsu reference document
+- `CLAUDE.md` — Project instructions including jj conventions and user preferences
+- `Makefile` — Convenience targets for jj operations (`jj-push`, `jj-status`, `jj-log`)
+- `.gitignore` — Includes `.jj/` directory exclusion

--- a/docs/adr/011-navigation-and-routing.md
+++ b/docs/adr/011-navigation-and-routing.md
@@ -1,0 +1,122 @@
+# ADR-011: Navigation and Routing
+
+**Status:** Accepted
+**Date:** 2026-02-06
+**Decision Makers:** Pascal Kraus
+
+## Context
+
+The website serves multiple content types — blog posts, interactive games, and utility tools — each requiring different page layouts and navigation patterns. As the number of features grew beyond a simple blog, a structured route hierarchy and consistent navigation system were needed to help users discover and move between sections. The site also requires locale-aware routing for English and German audiences.
+
+## Decision
+
+### Route Structure
+
+All routes use the `[locale]` dynamic segment for internationalization, creating a two-level content hierarchy organized by category:
+
+```
+app/[locale]/
+├── page.tsx                        (home)
+├── blog/                           (content section)
+│   ├── page.tsx                    (blog index)
+│   └── [slug]/page.tsx             (individual blog post)
+├── games/                          (interactive games)
+│   ├── page.tsx                    (games index — card grid)
+│   ├── wordle/page.tsx
+│   ├── wordle/demo/page.tsx
+│   ├── wordle/solver/page.tsx
+│   └── kniffel/page.tsx
+└── tools/                          (utility tools)
+    ├── page.tsx                    (tools index — card grid)
+    └── pomodoro/page.tsx
+```
+
+### Layout Hierarchy
+
+Two nested layouts wrap all pages:
+
+1. **Root layout** (`app/layout.tsx`): imports `globals.css`, sets up the base HTML structure
+2. **Locale layout** (`app/[locale]/layout.tsx`): wraps content with `ThemeProvider`, `NextIntlClientProvider`, renders the `Header` component, and constrains content width via `<main className="max-w-3xl">`
+
+### Header and Navigation
+
+The **Header** (`components/header.tsx`) is a sticky client component containing:
+- **SiteNav** dropdown for page navigation
+- Social links (GitHub, LinkedIn)
+- **LanguageSwitcher** for toggling between `en` and `de`
+- **ThemeToggle** for light/dark mode
+
+The **SiteNav** component (`components/site-nav.tsx`) implements a custom dropdown menu using:
+- `useState` for open/close state
+- `useRef` with click-outside detection for dismissal
+- Manual `Escape` key handling for keyboard accessibility
+- ARIA attributes: `aria-expanded`, `aria-haspopup`, `role="menu"`, `role="menuitem"`
+- Four navigation links: Home, Blog, Games, Tools
+- Translation namespace: `"nav"` via `useTranslations("nav")`
+
+This is a **custom implementation** rather than using the Radix UI `DropdownMenu` primitive that other shadcn/ui components are built on. The custom approach provides full control over the simple four-link menu without the additional bundle weight of Radix's full dropdown system.
+
+### Section Index Pages
+
+Games (`app/[locale]/games/page.tsx`) and Tools (`app/[locale]/tools/page.tsx`) index pages follow a shared pattern:
+- Server component with `getTranslations()` for i18n
+- `<h1>` heading with subtitle paragraph
+- Responsive card grid: `grid gap-4 sm:grid-cols-2`
+- Cards styled with `rounded-2xl border bg-card/60`
+- Call-to-action using shadcn `Button` with `asChild` wrapping a `Link`
+
+### Language Switching
+
+The **LanguageSwitcher** component performs a simple `pathname.replace()` to swap between `/en/...` and `/de/...`, preserving the current route path.
+
+### Known Inconsistencies
+
+- **SiteNav vs. Radix DropdownMenu**: the navigation dropdown is hand-rolled while other UI components use Radix primitives via shadcn/ui
+- **Back navigation**: games pages include manual back links (with hardcoded locale in the path), while tools pages have no back links
+- **Locale prop handling**: game pages pass `locale` as a prop to client components, while tools pages do not
+
+These inconsistencies reflect organic growth as features were added at different times. They are documented here for awareness rather than as immediate action items.
+
+## Consequences
+
+### Positive
+- The `[locale]` segment pattern provides clean, SEO-friendly URLs for both languages (`/en/games/wordle`, `/de/games/wordle`)
+- Category-based grouping (games, tools, blog) provides a clear mental model for both navigation and file organization
+- The card grid pattern for index pages is visually consistent and easy to extend with new features
+- Custom SiteNav keeps the navigation bundle small for a simple four-link menu
+- Sticky header ensures navigation is always accessible regardless of scroll position
+
+### Negative
+- Custom dropdown requires manual ARIA implementation that Radix DropdownMenu would provide automatically
+- Inconsistent back navigation between games and tools sections creates a fragmented UX
+- Hardcoded locale in back links is fragile and could break if locale handling changes
+- No breadcrumb trail for deep pages (e.g., `/games/wordle/solver`) — users rely on the dropdown or browser back
+- Section index pages duplicate layout patterns rather than sharing a generic section index component
+
+### Neutral
+- The four-link navigation is sufficient for the current site scope but would need redesign for significantly more sections
+- `max-w-3xl` content constraint in the locale layout works well for reading content but may be limiting for wider interactive features
+- The `LanguageSwitcher` approach of pathname replacement is simple but doesn't preserve query parameters or hash fragments
+
+## Alternatives Considered
+
+| Alternative | Reason Not Chosen |
+|------------|-------------------|
+| Single flat navigation (no categories) | Doesn't scale as features grow; no organizational structure for 5+ distinct pages |
+| Sidebar navigation | Overkill for a personal site with four top-level sections; consumes horizontal space on mobile |
+| Breadcrumb-based navigation | Adds visual clutter for a shallow route hierarchy (max 3 levels deep) |
+| Tab-based section switching | Works within a section but doesn't address cross-section navigation |
+| Radix DropdownMenu for SiteNav | Additional bundle size for a simple four-item menu; custom implementation provides equivalent functionality with less overhead |
+| next-intl navigation API (`createNavigation`) | Simple pathname replacement was sufficient; the full navigation API adds complexity without clear benefit for two locales |
+
+## References
+
+- `components/header.tsx` — Sticky header with navigation, social links, language switcher, theme toggle
+- `components/site-nav.tsx` — Custom dropdown navigation menu with ARIA support
+- `components/language-switcher.tsx` — Locale toggle component
+- `app/layout.tsx` — Root layout (CSS imports)
+- `app/[locale]/layout.tsx` — Locale layout (providers, header, content width constraint)
+- `app/[locale]/games/page.tsx` — Games section index page
+- `app/[locale]/tools/page.tsx` — Tools section index page
+- `middleware.ts` — Locale detection and routing middleware
+- `i18n/config.ts` — Locale configuration (`en`, `de`)

--- a/docs/adr/012-state-management.md
+++ b/docs/adr/012-state-management.md
@@ -1,0 +1,111 @@
+# ADR-012: State Management
+
+**Status:** Accepted
+**Date:** 2026-02-06
+**Decision Makers:** Pascal Kraus
+
+## Context
+
+The website's interactive features — Wordle, Kniffel, and Pomodoro timer — all require client-side state management for game/tool state and persistence across page reloads. Since these features are purely client-side with no server-side data requirements, a lightweight approach was needed that avoids unnecessary complexity while providing reliable state persistence. Each feature is independent with no shared state between them.
+
+## Decision
+
+### Core Pattern: `useState` + `useEffect` Persistence
+
+All features use the same fundamental pattern for state management:
+
+1. **Lazy initialization from localStorage**: `useState(() => loadFromStorage())`
+2. **Auto-save via `useEffect`**: persist state changes to localStorage on every relevant state update
+3. **Clear on reset**: dedicated `clearStorage()` functions for starting fresh
+
+There is **no global state management** — no React Context, no Zustand, no Redux. Each feature is fully self-contained with its own state, persistence, and lifecycle logic.
+
+### Storage Details by Feature
+
+| Aspect | Wordle | Kniffel | Pomodoro |
+|--------|--------|---------|----------|
+| Storage module | Inline in `components/wordle/use-wordle.ts` | Inline in `components/kniffel/use-kniffel.ts` | Separate `lib/pomodoro/storage.ts` |
+| Storage key(s) | `wordle-state-{locale}` | `kniffel-state` | `pomodoro:timer`, `pomodoro:stats` |
+| Validation | Minimal (`JSON.parse` + type cast) | Minimal (`JSON.parse` + type cast) | Runtime type guards |
+| Staleness handling | Locale mismatch detection | Game phase check | Day-based (`isSameDay` comparison) |
+| SSR guard | `typeof window === "undefined"` | `typeof window === "undefined"` | Not explicit in storage module |
+| Error handling | `try/catch` → return `null` | `try/catch` → return `null` | `try/catch` → return `null` |
+| Stored shape | `StoredGameState` (subset of full state) | `StoredGameState` (full state minus computed values) | `StoredTimerData` + `SessionRecord[]` |
+
+### Wordle State (`components/wordle/use-wordle.ts`)
+
+Stores a subset of game state keyed by locale (`wordle-state-en`, `wordle-state-de`). On load, validates that the stored locale matches the current locale; mismatches trigger a fresh game. State includes guesses, current input, game status, and the target word.
+
+### Kniffel State (`components/kniffel/use-kniffel.ts`)
+
+Stores the full game state minus computed values (score totals). On load, checks the game phase to determine if the stored state is still valid. A single `kniffel-state` key is used since the game is not locale-dependent.
+
+### Pomodoro State (`lib/pomodoro/storage.ts`)
+
+The most mature implementation with a dedicated storage module. Key differences from earlier features:
+
+- **Runtime type guards**: `isValidPresetId()`, `isValidPhase()`, `isValidPresetConfig()`, `isValidStoredTimer()`, `isValidSessionRecord()` — each validates structure and value ranges before accepting stored data
+- **Two separate stores**: timer state (`pomodoro:timer`) and session statistics (`pomodoro:stats`)
+- **Stats management**: `upsertTodayStats()` function for updating daily statistics with `MAX_STATS_DAYS = 90` day retention policy
+- **Time drift compensation**: on restore, adjusts timer state to account for elapsed time while the page was closed
+
+### Serialization
+
+All features use `JSON.stringify` / `JSON.parse` for serialization:
+- Dates are stored as ISO strings or `YYYY-MM-DD` format strings
+- No `Map` or `Set` types are persisted (these don't survive JSON round-tripping)
+- Stored objects are flat or shallowly nested
+
+### Additional React Patterns
+
+- **`setInterval`** for timer-based features (Pomodoro countdown)
+- **`useRef`** for values that shouldn't trigger re-renders (interval IDs, previous values)
+- **`useMemo`** for expensive derived computations (score calculations, schedule generation)
+- **`useCallback`** for stable function references passed to child components
+
+### No Shared Abstractions
+
+Each feature independently implements its own load/save/clear/SSR-guard patterns. There is no shared `useLocalStorage` hook or persistence utility. This means some boilerplate duplication exists across features, but each feature's storage logic can evolve independently (as evidenced by Pomodoro's more robust validation compared to earlier features).
+
+## Consequences
+
+### Positive
+- Zero additional dependencies — `useState` and `useEffect` are built into React
+- Each feature is fully self-contained and can be understood, tested, or removed independently
+- localStorage provides instant reads with no network latency, appropriate for single-user interactive tools
+- The Pomodoro storage module demonstrates a mature validation pattern that could guide future features
+- No global state means no risk of cross-feature state corruption or unintended coupling
+- Lazy `useState` initialization ensures hydration-safe loading without layout shifts
+
+### Negative
+- Boilerplate duplication across features (SSR guards, try/catch, JSON parse/serialize)
+- No shared `useLocalStorage` abstraction despite repeating the same pattern three times
+- Earlier features (Wordle, Kniffel) have minimal validation — corrupted localStorage could cause runtime errors
+- localStorage has a ~5MB limit per origin, which is sufficient now but could become a constraint
+- No data migration strategy — changing the stored shape requires handling old formats or clearing state
+- SSR guard inconsistency (Pomodoro storage module lacks explicit `typeof window` check)
+
+### Neutral
+- localStorage data is per-browser and per-device — no cross-device sync
+- Clearing browser data resets all game progress, which is acceptable for casual games/tools
+- The evolution from minimal validation (Wordle) to runtime type guards (Pomodoro) reflects natural codebase maturation
+- No server-side persistence means no user accounts or authentication are needed
+
+## Alternatives Considered
+
+| Alternative | Reason Not Chosen |
+|------------|-------------------|
+| Zustand | Adds a dependency for state that doesn't need to be shared across components; localStorage persistence plugin exists but is unnecessary given the simple patterns used |
+| Jotai | Atomic state model is elegant but overkill for features that manage state in a single hook |
+| React Context | Appropriate for shared state but each feature's state is consumed by a single component tree — prop drilling or hook returns are simpler |
+| IndexedDB | Async API adds complexity; localStorage's synchronous reads are simpler for small payloads; no need for structured queries or large data storage |
+| Server-side persistence (database) | Features are client-only interactive tools; server state adds latency, requires authentication, and needs hosting infrastructure for no meaningful benefit |
+| Shared `useLocalStorage` hook | Reasonable abstraction that could reduce duplication, but premature given that each feature's storage needs differ (validation depth, key structure, staleness logic) |
+
+## References
+
+- `components/wordle/use-wordle.ts` — Wordle state management and localStorage persistence
+- `components/kniffel/use-kniffel.ts` — Kniffel state management and localStorage persistence
+- `lib/pomodoro/storage.ts` — Pomodoro storage module with runtime type guards and stats management
+- `lib/pomodoro/types.ts` — Type definitions for `StoredTimerData`, `SessionRecord`, `PresetId`
+- `components/pomodoro/pomodoro-app.tsx` — Pomodoro state management (inline, no dedicated hook)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,69 @@
+# Architecture Decision Records (ADRs)
+
+This directory contains all Architecture Decision Records for the personal website project. ADRs document significant architectural choices and serve as the authoritative reference for how the codebase should evolve.
+
+## Governance
+
+**All new features, tools, and structural changes must align with these ADRs.** If a proposed change contradicts an existing ADR, the ADR must be updated first (with a new status like "Superseded by ADR-XXX" or "Amended") before the change is implemented.
+
+### ADR Lifecycle
+
+| Status | Meaning |
+|--------|---------|
+| **Proposed** | Under discussion, not yet accepted |
+| **Accepted** | Active decision that must be followed |
+| **Deprecated** | No longer recommended but existing code may still follow it |
+| **Superseded** | Replaced by a newer ADR (linked in the document) |
+
+### Adding a New ADR
+
+1. Use the next sequential number: `NNN-short-title.md`
+2. Follow the template format (see any existing ADR)
+3. Set status to "Proposed" until reviewed
+4. Update this README index
+
+## Index
+
+### Foundation
+
+| ADR | Title | Status | Summary |
+|-----|-------|--------|---------|
+| [001](001-framework-and-runtime.md) | Framework and Runtime | Accepted | Next.js 16 App Router, React 19, TypeScript 5.9 strict, bun runtime, standalone output |
+| [002](002-styling-and-theming.md) | Styling and Theming | Accepted | Tailwind CSS 4 (CSS-first), oklch color system, next-themes dark mode, semantic design tokens |
+| [003](003-internationalization.md) | Internationalization | Accepted | next-intl 4.8, en/de locales, always-prefixed routing, camelCase translation keys |
+| [004](004-ui-component-architecture.md) | UI Component Architecture | Accepted | shadcn/ui owned components, Radix UI primitives, CVA variants, cn() utility |
+
+### Features & Content
+
+| ADR | Title | Status | Summary |
+|-----|-------|--------|---------|
+| [005](005-interactive-feature-architecture.md) | Interactive Feature Architecture | Accepted | Four-layer pattern: pure logic → React hook → UI components → page route |
+| [006](006-content-management.md) | Content Management | Accepted | Local MDX files in content/{locale}/, gray-matter frontmatter, next-mdx-remote SSR |
+| [012](012-state-management.md) | State Management | Accepted | useState + useEffect + localStorage, no global state, per-feature isolation |
+
+### Quality & Testing
+
+| ADR | Title | Status | Summary |
+|-----|-------|--------|---------|
+| [007](007-testing-strategy.md) | Testing Strategy | Accepted | Vitest, pure function unit tests only, lib/__tests__/ organization, ~107 tests |
+| [008](008-code-quality-and-linting.md) | Code Quality and Linting | Accepted | Biome (replaces ESLint + Prettier), recommended rules, CI enforcement |
+
+### Infrastructure & Workflow
+
+| ADR | Title | Status | Summary |
+|-----|-------|--------|---------|
+| [009](009-infrastructure-and-deployment.md) | Infrastructure and Deployment | Accepted | Hetzner, Docker multi-stage build, Caddy reverse proxy, GitHub Actions CI/CD |
+| [010](010-version-control.md) | Version Control | Accepted | Jujutsu (jj), Git-compatible, bookmark conventions, conventional commits |
+| [011](011-navigation-and-routing.md) | Navigation and Routing | Accepted | [locale]-based routes, sticky header, section index card grids, SiteNav dropdown |
+
+## Known Inconsistencies
+
+All previously documented inconsistencies have been resolved (Phase 1 tech debt):
+
+1. ~~**Wordle i18n**~~ — Migrated to `useTranslations()` and `useLocale()`
+2. ~~**Pomodoro structure**~~ — Extracted `usePomodoro()` hook and barrel exports
+3. ~~**SiteNav dropdown**~~ — Replaced with Radix `DropdownMenu` primitives
+4. ~~**Back navigation**~~ — All pages use `nav.back` translation key
+5. ~~**Storage validation**~~ — Wordle and Kniffel now use type guards matching Pomodoro pattern
+6. ~~**Unused test dependencies**~~ — Removed `@testing-library/dom`, `@testing-library/react`, `jsdom`
+7. ~~**Tests not in CI**~~ — Added `bun run test` step to CI pipeline

--- a/lib/kniffel/index.ts
+++ b/lib/kniffel/index.ts
@@ -1,3 +1,4 @@
 export * from "./dice";
 export * from "./scoring";
+export * from "./storage";
 export * from "./types";

--- a/lib/kniffel/storage.ts
+++ b/lib/kniffel/storage.ts
@@ -1,0 +1,62 @@
+import type { GameMode, GamePhase, StoredGameState } from "./types";
+
+const STORAGE_KEY = "kniffel-state";
+
+function isValidGameMode(m: unknown): m is GameMode {
+  return typeof m === "string" && ["digital", "tracker"].includes(m);
+}
+
+function isValidGamePhase(p: unknown): p is GamePhase {
+  return (
+    typeof p === "string" &&
+    ["mode-select", "setup", "playing", "finished"].includes(p)
+  );
+}
+
+function isValidStoredGameState(data: unknown): data is StoredGameState {
+  if (typeof data !== "object" || data === null) return false;
+  const obj = data as Record<string, unknown>;
+
+  if (!isValidGameMode(obj.mode)) return false;
+  if (!isValidGamePhase(obj.phase)) return false;
+  if (!Array.isArray(obj.players)) return false;
+  if (typeof obj.currentPlayerIndex !== "number") return false;
+  if (typeof obj.currentTurn !== "number") return false;
+  if (!Array.isArray(obj.dice)) return false;
+  if (typeof obj.rollsRemaining !== "number") return false;
+  if (typeof obj.hasRolled !== "boolean") return false;
+  if (typeof obj.timestamp !== "number") return false;
+
+  return true;
+}
+
+export function loadGameState(): StoredGameState | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) return null;
+    const data: unknown = JSON.parse(stored);
+    if (!isValidStoredGameState(data)) return null;
+    return data;
+  } catch {
+    return null;
+  }
+}
+
+export function saveGameState(state: StoredGameState): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // Ignore storage errors
+  }
+}
+
+export function clearGameState(): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // Ignore storage errors
+  }
+}

--- a/lib/pomodoro/index.ts
+++ b/lib/pomodoro/index.ts
@@ -1,0 +1,5 @@
+export * from "./constants";
+export * from "./notifications";
+export * from "./scheduler";
+export * from "./storage";
+export * from "./types";

--- a/lib/wordle/storage.ts
+++ b/lib/wordle/storage.ts
@@ -1,0 +1,78 @@
+import type { GameState, StoredGameState } from "./types";
+
+const STORAGE_KEY_PREFIX = "wordle-state-";
+
+function getStorageKey(locale: string): string {
+  return `${STORAGE_KEY_PREFIX}${locale}`;
+}
+
+function isValidLetterState(s: unknown): boolean {
+  return s === "correct" || s === "present" || s === "absent";
+}
+
+function isValidGameStatus(s: unknown): boolean {
+  return s === "playing" || s === "won" || s === "lost";
+}
+
+function isValidStoredGameState(data: unknown): data is StoredGameState {
+  if (typeof data !== "object" || data === null) return false;
+  const obj = data as Record<string, unknown>;
+
+  if (typeof obj.solution !== "string") return false;
+  if (
+    !Array.isArray(obj.guesses) ||
+    !obj.guesses.every((g: unknown) => typeof g === "string")
+  )
+    return false;
+  if (!isValidGameStatus(obj.gameStatus)) return false;
+
+  const letterStates = obj.letterStates;
+  if (typeof letterStates !== "object" || letterStates === null) return false;
+  for (const value of Object.values(letterStates as Record<string, unknown>)) {
+    if (!isValidLetterState(value)) return false;
+  }
+
+  if (typeof obj.locale !== "string") return false;
+  if (typeof obj.timestamp !== "number") return false;
+
+  return true;
+}
+
+export function loadGameState(locale: string): StoredGameState | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const stored = localStorage.getItem(getStorageKey(locale));
+    if (!stored) return null;
+    const data: unknown = JSON.parse(stored);
+    if (!isValidStoredGameState(data)) return null;
+    return data;
+  } catch {
+    return null;
+  }
+}
+
+export function saveGameState(state: GameState, locale: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    const toStore: StoredGameState = {
+      solution: state.solution,
+      guesses: state.guesses,
+      gameStatus: state.gameStatus,
+      letterStates: state.letterStates,
+      locale,
+      timestamp: Date.now(),
+    };
+    localStorage.setItem(getStorageKey(locale), JSON.stringify(toStore));
+  } catch {
+    // Ignore storage errors
+  }
+}
+
+export function clearGameState(locale: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.removeItem(getStorageKey(locale));
+  } catch {
+    // Ignore storage errors
+  }
+}

--- a/messages/de.json
+++ b/messages/de.json
@@ -21,7 +21,8 @@
     "home": "Startseite",
     "blog": "Blog",
     "games": "Spiele",
-    "tools": "Werkzeuge"
+    "tools": "Werkzeuge",
+    "back": "zurück"
   },
   "games": {
     "title": "Spiele",
@@ -35,6 +36,9 @@
       "notEnough": "Nicht genug Buchstaben",
       "youWin": "Gewonnen!",
       "youLose": "Das Wort war {word}",
+      "reset": "Neu starten",
+      "showKeyboard": "Tastatur",
+      "hideKeyboard": "Tastatur ausblenden",
       "solver": {
         "title": "Wordle Solver",
         "description": "Hilfe beim Lösen von Wordle-Rätseln",
@@ -51,6 +55,13 @@
         "noMatches": "Keine passenden Wörter gefunden",
         "enterGuess": "Gib deinen Versuch ein und markiere jeden Buchstaben",
         "clickToMark": "Klicke auf Kacheln: absent \u2192 present \u2192 correct",
+        "failed": "Fehlgeschlagen. Das Wort war {word}",
+        "loading": "Lädt...",
+        "absent": "Falsch",
+        "present": "Falsche Stelle",
+        "correct": "Richtig",
+        "getSuggestions": "Vorschlag holen",
+        "solution": "Lösung",
         "controls": {
           "play": "Start",
           "pause": "Pause",

--- a/messages/en.json
+++ b/messages/en.json
@@ -21,7 +21,8 @@
     "home": "Home",
     "blog": "Blog",
     "games": "Games",
-    "tools": "Tools"
+    "tools": "Tools",
+    "back": "back"
   },
   "games": {
     "title": "Games",
@@ -35,6 +36,9 @@
       "notEnough": "Not enough letters",
       "youWin": "You won!",
       "youLose": "The word was {word}",
+      "reset": "Reset",
+      "showKeyboard": "Keyboard",
+      "hideKeyboard": "Hide Keyboard",
       "solver": {
         "title": "Wordle Solver",
         "description": "Get help solving any Wordle puzzle",
@@ -51,6 +55,13 @@
         "noMatches": "No matching words found",
         "enterGuess": "Enter your guess and mark each letter",
         "clickToMark": "Click tiles to cycle: absent \u2192 present \u2192 correct",
+        "failed": "Failed. The word was {word}",
+        "loading": "Loading...",
+        "absent": "Absent",
+        "present": "Present",
+        "correct": "Correct",
+        "getSuggestions": "Get Suggestions",
+        "solution": "Solution",
         "controls": {
           "play": "Play",
           "pause": "Pause",

--- a/package.json
+++ b/package.json
@@ -14,12 +14,9 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.13",
-    "@testing-library/dom": "^10.4.1",
-    "@testing-library/react": "^16.3.2",
     "@types/bun": "latest",
     "@types/node": "^25.1.0",
     "@types/react": "^19.2.10",
-    "jsdom": "^28.0.0",
     "tw-animate-css": "^1.4.0",
     "vitest": "^4.0.18"
   },


### PR DESCRIPTION
## Summary

Resolves all 7 known architectural inconsistencies documented in the ADR system, bringing the entire codebase into compliance with established patterns.

### ADR Documentation (new)
- 12 Architecture Decision Records in `docs/adr/` covering framework, styling, i18n, components, features, content, testing, linting, infrastructure, VCS, navigation, and state management
- Implementation plan at `docs/IMPLEMENTATION_PLAN.md` with 3 phases

### Tech Debt Resolved
- **Wordle i18n**: Migrated 7 components from inline `locale === "de"` checks to `useTranslations()` + `useLocale()`
- **Pomodoro structure**: Extracted `usePomodoro()` hook (589→245 lines), created barrel exports
- **SiteNav dropdown**: Replaced custom useState/useRef/useEffect with Radix `DropdownMenu` primitives
- **Back navigation**: All feature pages now use `nav.back` translation key
- **Storage validation**: Created `lib/wordle/storage.ts` and `lib/kniffel/storage.ts` with type guards
- **Unused deps**: Removed `@testing-library/dom`, `@testing-library/react`, `jsdom`
- **CI testing**: Added `bun run test` step to GitHub Actions pipeline

## Test plan
- [x] `bun run check` — 0 lint errors (100 files)
- [x] `bun run test` — 130/130 tests passing
- [x] `bun run build` — TypeScript + Next.js production build succeeds
- [ ] Manual: navigate all pages, verify back links, switch EN↔DE, test SiteNav dropdown
- [ ] Manual: play Wordle (EN + DE), start Pomodoro session, open Kniffel
- [ ] Manual: verify dark mode on all pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)