### PR TITLE
chore: update GitHub profile links after username rename

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -29,7 +29,7 @@ export default function Home() {
         </a>
         {t("cta.comma")}{" "}
         <a
-          href="https://x.com/BearWithAI"
+          href="https://x.com/pagoell"
           target="_blank"
           rel="noopener noreferrer"
           className="underline"

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -20,7 +20,7 @@ export default function Home() {
         </Link>{" "}
         {t("cta.or")}{" "}
         <a
-          href="https://github.com/Spycner"
+          href="https://github.com/pgoell"
           target="_blank"
           rel="noopener noreferrer"
           className="underline"

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -83,7 +83,7 @@ export function Header() {
 
           <Button variant="ghost" size="icon" asChild>
             <a
-              href="https://github.com/Spycner"
+              href="https://github.com/pgoell"
               target="_blank"
               rel="noopener noreferrer"
               aria-label="GitHub"

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -61,7 +61,7 @@ export function Header() {
         <div className="flex items-center gap-1">
           <Button variant="ghost" size="icon" asChild>
             <a
-              href="https://x.com/BearWithAI"
+              href="https://x.com/pagoell"
               target="_blank"
               rel="noopener noreferrer"
               aria-label="X (Twitter)"


### PR DESCRIPTION
## Summary
- Updated GitHub profile URLs in `page.tsx` and `header.tsx` from Spycner → pgoell

Reflects GitHub username change.