### PR TITLE
feat: rework site character to brutalist mono

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 .DS_Store
 
 .next
+
+# local playgrounds (single-file HTML design tools, not source)
+*.playground.html

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -7,44 +7,48 @@ export default function Home() {
 
   return (
     <div className="space-y-6">
+      <h1 className="text-2xl font-semibold tracking-tight">{t("greeting")}</h1>
+
       <p>{t("intro")}</p>
 
-      {/* <p>{t("mission")}</p> */}
-
-      {/* <p>{t("personal")}</p> */}
-
       <p>
-        {t("cta.prefix")}{" "}
-        <Link href={`/${locale}/blog`} className="underline">
-          {t("cta.writing")}
-        </Link>{" "}
-        {t("cta.or")}{" "}
-        <a
-          href="https://github.com/pgoell"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="underline"
-        >
-          {t("cta.code")}
-        </a>
-        ,{" "}
-        <Link href={`/${locale}/games`} className="underline">
-          {t("cta.playGames")}
-        </Link>
-        {t("cta.comma")}{" "}
-        <a
-          href="https://x.com/pagoell"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="underline"
-        >
-          {t("cta.follow")}
-        </a>
-        {t("cta.period")}{" "}
-        <a href="mailto:hello@pascalkraus.com" className="underline">
-          {t("cta.reachOut")}
-        </a>
-        {t("cta.suffix")}
+        {t.rich("cta", {
+          writing: (chunks) => (
+            <Link href={`/${locale}/blog`} className="underline">
+              {chunks}
+            </Link>
+          ),
+          code: (chunks) => (
+            <a
+              href="https://github.com/pgoell"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline"
+            >
+              {chunks}
+            </a>
+          ),
+          games: (chunks) => (
+            <Link href={`/${locale}/games`} className="underline">
+              {chunks}
+            </Link>
+          ),
+          follow: (chunks) => (
+            <a
+              href="https://x.com/pagoell"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline"
+            >
+              {chunks}
+            </a>
+          ),
+          reachOut: (chunks) => (
+            <a href="mailto:hello@pascalkraus.com" className="underline">
+              {chunks}
+            </a>
+          ),
+        })}
       </p>
     </div>
   );

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,130 +1,121 @@
 @import "tailwindcss";
 
 :root {
-  --background: oklch(0.9914 0.0098 87.4695);
-  --foreground: oklch(0.3296 0.0122 62.2125);
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.18 0 0);
   --wordle-correct: oklch(0.65 0.17 145);
   --wordle-present: oklch(0.75 0.15 85);
-  --card: oklch(0.9688 0.0119 79.7848);
-  --card-foreground: oklch(0.3296 0.0122 62.2125);
-  --popover: oklch(0.9914 0.0098 87.4695);
-  --popover-foreground: oklch(0.3296 0.0122 62.2125);
-  --primary: oklch(0.5954 0.084 143.4195);
+  --card: oklch(0.975 0 0);
+  --card-foreground: oklch(0.18 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.18 0 0);
+  --primary: oklch(0.6 0.15 175);
   --primary-foreground: oklch(1 0 0);
-  --secondary: oklch(0.7063 0.0564 227.2095);
+  --secondary: oklch(0.18 0 0);
   --secondary-foreground: oklch(1 0 0);
-  --muted: oklch(0.9365 0.0206 81.7807);
-  --muted-foreground: oklch(0.5579 0.0208 70.0358);
-  --accent: oklch(0.883 0.0596 64.4503);
-  --accent-foreground: oklch(0.4168 0.0436 68.8424);
-  --destructive: oklch(0.652 0.1363 29.5653);
+  --muted: oklch(0.96 0 0);
+  --muted-foreground: oklch(0.5 0 0);
+  --accent: oklch(0.94 0.04 175);
+  --accent-foreground: oklch(0.18 0 0);
+  --destructive: oklch(0.5 0.2 25);
   --destructive-foreground: oklch(1 0 0);
-  --border: oklch(0.907 0.0212 79.0883);
-  --input: oklch(0.9483 0.0177 81.3313);
-  --ring: oklch(0.5954 0.084 143.4195);
-  --chart-1: oklch(0.5954 0.084 143.4195);
-  --chart-2: oklch(0.7063 0.0564 227.2095);
-  --chart-3: oklch(0.8052 0.1329 78.1498);
-  --chart-4: oklch(0.652 0.1363 29.5653);
-  --chart-5: oklch(0.6684 0.0684 316.8892);
-  --sidebar: oklch(0.9579 0.0153 77.0712);
-  --sidebar-foreground: oklch(0.3296 0.0122 62.2125);
-  --sidebar-primary: oklch(0.5954 0.084 143.4195);
+  --border: oklch(0.18 0 0);
+  --input: oklch(0.92 0 0);
+  --ring: oklch(0.6 0.15 175);
+  --chart-1: oklch(0.6 0.15 175);
+  --chart-2: oklch(0.6 0.18 250);
+  --chart-3: oklch(0.65 0.18 80);
+  --chart-4: oklch(0.5 0.2 25);
+  --chart-5: oklch(0.5 0.15 290);
+  --sidebar: oklch(0.975 0 0);
+  --sidebar-foreground: oklch(0.18 0 0);
+  --sidebar-primary: oklch(0.6 0.15 175);
   --sidebar-primary-foreground: oklch(1 0 0);
-  --sidebar-accent: oklch(0.9255 0.024 79.7388);
-  --sidebar-accent-foreground: oklch(0.3296 0.0122 62.2125);
-  --sidebar-border: oklch(0.907 0.0212 79.0883);
-  --sidebar-ring: oklch(0.5954 0.084 143.4195);
-  --font-sans: "Quicksand", system-ui, sans-serif;
-  --font-serif: "Lora", Georgia, serif;
-  --font-mono: "Fira Code", monospace;
-  --radius: 1rem;
-  --shadow-x: 0px;
+  --sidebar-accent: oklch(0.94 0.04 175);
+  --sidebar-accent-foreground: oklch(0.18 0 0);
+  --sidebar-border: oklch(0.18 0 0);
+  --sidebar-ring: oklch(0.6 0.15 175);
+  --font-sans:
+    "JetBrains Mono", ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+  --font-serif:
+    "JetBrains Mono", ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+  --font-mono:
+    "JetBrains Mono", ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+  --radius: 0rem;
+  --shadow-x: 4px;
   --shadow-y: 4px;
-  --shadow-blur: 12px;
+  --shadow-blur: 0px;
   --shadow-spread: 0px;
-  --shadow-opacity: 0.08;
-  --shadow-color: #3a342f;
-  --shadow-2xs: 0px 4px 12px 0px hsl(27.2727 10.4762% 20.5882% / 0.04);
-  --shadow-xs: 0px 4px 12px 0px hsl(27.2727 10.4762% 20.5882% / 0.04);
-  --shadow-sm:
-    0px 4px 12px 0px hsl(27.2727 10.4762% 20.5882% / 0.08),
-    0px 1px 2px -1px hsl(27.2727 10.4762% 20.5882% / 0.08);
-  --shadow:
-    0px 4px 12px 0px hsl(27.2727 10.4762% 20.5882% / 0.08),
-    0px 1px 2px -1px hsl(27.2727 10.4762% 20.5882% / 0.08);
-  --shadow-md:
-    0px 4px 12px 0px hsl(27.2727 10.4762% 20.5882% / 0.08),
-    0px 2px 4px -1px hsl(27.2727 10.4762% 20.5882% / 0.08);
-  --shadow-lg:
-    0px 4px 12px 0px hsl(27.2727 10.4762% 20.5882% / 0.08),
-    0px 4px 6px -1px hsl(27.2727 10.4762% 20.5882% / 0.08);
-  --shadow-xl:
-    0px 4px 12px 0px hsl(27.2727 10.4762% 20.5882% / 0.08),
-    0px 8px 10px -1px hsl(27.2727 10.4762% 20.5882% / 0.08);
-  --shadow-2xl: 0px 4px 12px 0px hsl(27.2727 10.4762% 20.5882% / 0.2);
-  --tracking-normal: 0.01em;
-  --spacing: 0.25rem;
+  --shadow-opacity: 1;
+  --shadow-color: oklch(0.18 0 0);
+  --shadow-2xs: 2px 2px 0 0 oklch(0.18 0 0);
+  --shadow-xs: 2px 2px 0 0 oklch(0.18 0 0);
+  --shadow-sm: 4px 4px 0 0 oklch(0.18 0 0);
+  --shadow: 4px 4px 0 0 oklch(0.18 0 0);
+  --shadow-md: 4px 4px 0 0 oklch(0.18 0 0);
+  --shadow-lg: 6px 6px 0 0 oklch(0.18 0 0);
+  --shadow-xl: 8px 8px 0 0 oklch(0.18 0 0);
+  --shadow-2xl: 10px 10px 0 0 oklch(0.18 0 0);
+  --tracking-normal: 0em;
+  --spacing: 0.213rem;
 }
 
 .dark {
-  --background: oklch(0.2225 0.0041 84.5879);
-  --foreground: oklch(0.9428 0.0153 77.0696);
+  --background: oklch(0.16 0 0);
+  --foreground: oklch(0.96 0 0);
   --wordle-correct: oklch(0.55 0.17 145);
   --wordle-present: oklch(0.65 0.15 85);
-  --card: oklch(0.2617 0.0047 67.6183);
-  --card-foreground: oklch(0.9428 0.0153 77.0696);
-  --popover: oklch(0.2225 0.0041 84.5879);
-  --popover-foreground: oklch(0.9428 0.0153 77.0696);
-  --primary: oklch(0.7298 0.0667 143.5089);
-  --primary-foreground: oklch(0.2225 0.0041 84.5879);
-  --secondary: oklch(0.7803 0.043 215.544);
-  --secondary-foreground: oklch(0.2225 0.0041 84.5879);
-  --muted: oklch(0.3109 0.0082 75.2711);
-  --muted-foreground: oklch(0.7002 0.0201 75.2529);
-  --accent: oklch(0.3983 0.0175 74.1664);
-  --accent-foreground: oklch(0.9428 0.0153 77.0696);
-  --destructive: oklch(0.5175 0.1062 29.4814);
+  --card: oklch(0.21 0 0);
+  --card-foreground: oklch(0.96 0 0);
+  --popover: oklch(0.16 0 0);
+  --popover-foreground: oklch(0.96 0 0);
+  --primary: oklch(0.72 0.15 175);
+  --primary-foreground: oklch(0.16 0 0);
+  --secondary: oklch(0.96 0 0);
+  --secondary-foreground: oklch(0.16 0 0);
+  --muted: oklch(0.22 0 0);
+  --muted-foreground: oklch(0.7 0 0);
+  --accent: oklch(0.27 0.03 175);
+  --accent-foreground: oklch(0.96 0 0);
+  --destructive: oklch(0.6 0.2 25);
   --destructive-foreground: oklch(1 0 0);
-  --border: oklch(0.3469 0.0102 73.5699);
-  --input: oklch(0.2749 0.007 67.5293);
-  --ring: oklch(0.7298 0.0667 143.5089);
-  --chart-1: oklch(0.7298 0.0667 143.5089);
-  --chart-2: oklch(0.7803 0.043 215.544);
-  --chart-3: oklch(0.7507 0.1295 79.8494);
-  --chart-4: oklch(0.5175 0.1062 29.4814);
-  --chart-5: oklch(0.5849 0.0683 312.9161);
-  --sidebar: oklch(0.1965 0.0026 67.6778);
-  --sidebar-foreground: oklch(0.9428 0.0153 77.0696);
-  --sidebar-primary: oklch(0.7298 0.0667 143.5089);
-  --sidebar-primary-foreground: oklch(0.2225 0.0041 84.5879);
-  --sidebar-accent: oklch(0.2617 0.0047 67.6183);
-  --sidebar-accent-foreground: oklch(0.9428 0.0153 77.0696);
-  --sidebar-border: oklch(0.3469 0.0102 73.5699);
-  --sidebar-ring: oklch(0.7298 0.0667 143.5089);
-  --font-sans: "Quicksand", system-ui, sans-serif;
-  --font-serif: "Lora", Georgia, serif;
-  --font-mono: Special Elite, ui-serif, serif;
-  --radius: 1rem;
-  --shadow-x: 0px;
-  --shadow-y: 8px;
-  --shadow-blur: 20px;
+  --border: oklch(0.96 0 0);
+  --input: oklch(0.3 0 0);
+  --ring: oklch(0.72 0.15 175);
+  --chart-1: oklch(0.72 0.15 175);
+  --chart-2: oklch(0.7 0.18 250);
+  --chart-3: oklch(0.75 0.18 80);
+  --chart-4: oklch(0.6 0.2 25);
+  --chart-5: oklch(0.6 0.15 290);
+  --sidebar: oklch(0.13 0 0);
+  --sidebar-foreground: oklch(0.96 0 0);
+  --sidebar-primary: oklch(0.72 0.15 175);
+  --sidebar-primary-foreground: oklch(0.16 0 0);
+  --sidebar-accent: oklch(0.27 0.03 175);
+  --sidebar-accent-foreground: oklch(0.96 0 0);
+  --sidebar-border: oklch(0.96 0 0);
+  --sidebar-ring: oklch(0.72 0.15 175);
+  --font-sans:
+    "JetBrains Mono", ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+  --font-serif:
+    "JetBrains Mono", ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+  --font-mono:
+    "JetBrains Mono", ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+  --radius: 0rem;
+  --shadow-x: 4px;
+  --shadow-y: 4px;
+  --shadow-blur: 0px;
   --shadow-spread: 0px;
-  --shadow-opacity: 0.4;
-  --shadow-color: #000000;
-  --shadow-2xs: 0px 8px 20px 0px hsl(0 0% 0% / 0.2);
-  --shadow-xs: 0px 8px 20px 0px hsl(0 0% 0% / 0.2);
-  --shadow-sm:
-    0px 8px 20px 0px hsl(0 0% 0% / 0.4), 0px 1px 2px -1px hsl(0 0% 0% / 0.4);
-  --shadow:
-    0px 8px 20px 0px hsl(0 0% 0% / 0.4), 0px 1px 2px -1px hsl(0 0% 0% / 0.4);
-  --shadow-md:
-    0px 8px 20px 0px hsl(0 0% 0% / 0.4), 0px 2px 4px -1px hsl(0 0% 0% / 0.4);
-  --shadow-lg:
-    0px 8px 20px 0px hsl(0 0% 0% / 0.4), 0px 4px 6px -1px hsl(0 0% 0% / 0.4);
-  --shadow-xl:
-    0px 8px 20px 0px hsl(0 0% 0% / 0.4), 0px 8px 10px -1px hsl(0 0% 0% / 0.4);
-  --shadow-2xl: 0px 8px 20px 0px hsl(0 0% 0% / 1);
+  --shadow-opacity: 1;
+  --shadow-color: oklch(0.96 0 0);
+  --shadow-2xs: 2px 2px 0 0 oklch(0.96 0 0);
+  --shadow-xs: 2px 2px 0 0 oklch(0.96 0 0);
+  --shadow-sm: 4px 4px 0 0 oklch(0.96 0 0);
+  --shadow: 4px 4px 0 0 oklch(0.96 0 0);
+  --shadow-md: 4px 4px 0 0 oklch(0.96 0 0);
+  --shadow-lg: 6px 6px 0 0 oklch(0.96 0 0);
+  --shadow-xl: 8px 8px 0 0 oklch(0.96 0 0);
+  --shadow-2xl: 10px 10px 0 0 oklch(0.96 0 0);
 }
 
 @theme inline {
@@ -165,10 +156,14 @@
   --font-mono: var(--font-mono);
   --font-serif: var(--font-serif);
 
-  --radius-sm: calc(var(--radius) - 4px);
-  --radius-md: calc(var(--radius) - 2px);
+  --radius-xs: var(--radius);
+  --radius-sm: var(--radius);
+  --radius-md: var(--radius);
   --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) + 4px);
+  --radius-xl: var(--radius);
+  --radius-2xl: var(--radius);
+  --radius-3xl: var(--radius);
+  --radius-4xl: var(--radius);
 
   --shadow-2xs: var(--shadow-2xs);
   --shadow-xs: var(--shadow-xs);
@@ -191,6 +186,34 @@ body {
   background-color: var(--background);
   color: var(--foreground);
   letter-spacing: var(--tracking-normal);
+  font-size: 15px;
+  font-weight: 500;
+}
+
+@layer utilities {
+  .border {
+    border-width: 2px;
+  }
+  .border-t {
+    border-top-width: 2px;
+  }
+  .border-r {
+    border-right-width: 2px;
+  }
+  .border-b {
+    border-bottom-width: 2px;
+  }
+  .border-l {
+    border-left-width: 2px;
+  }
+  .border-x {
+    border-left-width: 2px;
+    border-right-width: 2px;
+  }
+  .border-y {
+    border-top-width: 2px;
+    border-bottom-width: 2px;
+  }
 }
 
 /* Wordle animations */

--- a/docs/adr/002-styling-and-theming.md
+++ b/docs/adr/002-styling-and-theming.md
@@ -6,7 +6,9 @@
 
 ## Context
 
-The website needs a comprehensive styling system that supports light and dark themes, semantic design tokens, responsive design, and custom typography. The system must integrate cleanly with React Server Components and the shadcn/ui component pattern, while allowing per-theme personality (e.g., different monospace fonts in dark mode).
+The website needs a comprehensive styling system that supports light and dark themes, semantic design tokens, responsive design, and custom typography. The system must integrate cleanly with React Server Components and the shadcn/ui component pattern, while expressing a single cohesive visual character across both themes.
+
+The site's character is **brutalist mono**: pure white / near-black surfaces, JetBrains Mono across all font roles, sharp 0-radius corners, hard offset shadows, heavy 2px borders, tight density, teal accent. Both themes share the same character; only luminance flips.
 
 ## Decision
 
@@ -22,8 +24,9 @@ The project uses **Tailwind CSS ^4.1.18** with the new CSS-first configuration m
 
 All color tokens use the **oklch** color space for perceptual uniformity. Colors are defined as CSS custom properties in `:root` (light) and `.dark` (dark) scopes:
 
-- **Light theme** (`globals.css:3-68`): Warm off-white background (`oklch(0.9914 0.0098 87.4695)`), green primary, blue secondary
-- **Dark theme** (`globals.css:70-128`): Warm dark background (`oklch(0.2225 0.0041 84.5879)`), all tokens have dark counterparts
+- **Light theme:** Pure white background (`oklch(1 0 0)`), near-black foreground (`oklch(0.18 0 0)`), teal primary (`oklch(0.6 0.15 175)`)
+- **Dark theme:** Near-black background (`oklch(0.16 0 0)`), near-white foreground (`oklch(0.96 0 0)`), brightened teal primary (`oklch(0.72 0.15 175)`)
+- **Border tokens** are set to the full foreground color (not a muted tint) — borders are part of the visual statement, not background separators
 - **Semantic tokens:** `background`, `foreground`, `primary`, `secondary`, `accent`, `destructive`, `muted`, `card`, `popover`, `border`, `input`, `ring`, `chart-1` through `chart-5`, `sidebar-*`, `wordle-correct`, `wordle-present`
 
 ### Theme Switching: next-themes
@@ -36,28 +39,29 @@ All color tokens use the **oklch** color space for perceptual uniformity. Colors
 
 ### Typography
 
-Three font families are registered as CSS custom properties and bridged to Tailwind via `@theme inline`:
+All three font families resolve to **JetBrains Mono** with `ui-monospace` and system-mono fallbacks. The brutalist character requires consistent monospace across body, headings, and code.
 
 | Token | Light Mode | Dark Mode |
 |-------|-----------|-----------|
-| `--font-sans` | Quicksand, system-ui, sans-serif | Quicksand, system-ui, sans-serif |
-| `--font-serif` | Lora, Georgia, serif | Lora, Georgia, serif |
-| `--font-mono` | Fira Code, monospace | Special Elite, ui-serif, serif |
+| `--font-sans` | JetBrains Mono, ui-monospace, … | JetBrains Mono, ui-monospace, … |
+| `--font-serif` | JetBrains Mono, ui-monospace, … | JetBrains Mono, ui-monospace, … |
+| `--font-mono` | JetBrains Mono, ui-monospace, … | JetBrains Mono, ui-monospace, … |
 
-The dark mode monospace swap to **Special Elite** (`globals.css:107`) is an intentional design choice that gives dark mode a playful, typewriter aesthetic.
+The body element defaults to `font-size: 15px` and `font-weight: 500` — slightly denser than browser defaults to support the tight-density character.
 
 ### Shadow System
 
-Light and dark themes have distinctly different shadow aesthetics:
+Shadows are **hard offset** (no blur, no opacity, in the foreground color) across all sizes. This makes shadows read as a graphic, intentional element rather than ambient depth:
 
-- **Light** (`globals.css:42-65`): Subtle warm shadows with `0.08` opacity, `4px` y-offset, `12px` blur, using `hsl(27.27 10.48% 20.59%)`
-- **Dark** (`globals.css:109-127`): Dramatic shadows with `0.4` opacity, `8px` y-offset, `20px` blur, using pure black
+- **Light:** `Npx Npx 0 0 oklch(0.18 0 0)` where N grows with size (2 → 10)
+- **Dark:** Same shape, foreground color flipped to `oklch(0.96 0 0)`
 
 ### Layout Tokens
 
-- **Spacing base:** `--spacing: 0.25rem` (`globals.css:67`)
-- **Border radius:** Base `--radius: 1rem`, computed variants via `calc()` at `globals.css:168-171` (`sm: -4px`, `md: -2px`, `lg: base`, `xl: +4px`)
-- **Letter spacing:** Base `--tracking-normal: 0.01em` with computed tighter/wider variants (`globals.css:182-187`)
+- **Spacing base:** `--spacing: 0.213rem` (~85% of the comfortable default — tightens every Tailwind spacing utility proportionally)
+- **Border radius:** `--radius: 0rem` — sharp corners everywhere; computed variants in `@theme inline` resolve to 0 / 0 / 0 / 4px
+- **Letter spacing:** `--tracking-normal: 0em` — no tracking, native mono metrics
+- **Default border width:** A `@layer utilities` override raises Tailwind's `.border` and side-specific border classes from 1px to 2px, so any element opting into a border gets the heavy brutalist weight without per-component edits
 
 ### Custom Animations
 
@@ -70,13 +74,14 @@ Only one custom animation exists: `shake` for Wordle invalid guess feedback (`gl
 - oklch provides perceptually uniform color spacing — adjusting lightness/chroma is predictable
 - Semantic tokens (`primary`, `secondary`, etc.) decouple component styles from specific color values
 - `@theme inline` block makes all CSS variables available as Tailwind utilities (`bg-primary`, `text-muted-foreground`, etc.)
-- Per-theme typography gives each mode a distinct personality without extra complexity
+- A single shared character across both themes keeps the brand consistent — light and dark are luminance flips of the same design language
 - `disableTransitionOnChange` prevents flash-of-wrong-theme during switches
 
 ### Negative
 - oklch has limited browser DevTools support for visual color picking
 - The `@theme inline` bridge layer adds ~60 lines of boilerplate to map CSS vars to Tailwind tokens
-- Per-theme font changes (monospace) may surprise users who expect consistency across themes
+- All-monospace typography is a strong opinion — readers expecting a softer body font will notice
+- The default border width override means any future `border` class change ripples across the app; explicit `border-0` is required to opt out
 - No `@tailwindcss/typography` plugin (incompatible with Tailwind v4), so MDX prose styles must be manually applied
 
 ### Neutral

--- a/messages/de.json
+++ b/messages/de.json
@@ -1,20 +1,8 @@
 {
   "home": {
-    "intro": "Ich bin Entwickler und Autor. Ich arbeite bei Deloitte als Berater für Data Engineering und AI Engineering mit starkem Fokus auf Databricks. Zuvor war ich AI Engineer bei der Deutschen Bundesbank.",
-    "mission": "Meine Lebensaufgabe ist [deine Mission]. Ich interessiere mich für [Interessen].",
-    "personal": "Ich bin [persönliche Details]. Zuletzt gehört: [Song] von [Künstler].",
-    "cta": {
-      "prefix": "Du kannst meine",
-      "writing": "Artikel",
-      "or": "oder meinen",
-      "code": "Code lesen",
-      "comma": " oder mir",
-      "follow": "online folgen",
-      "period": ".",
-      "reachOut": "Melde dich",
-      "suffix": ", wenn du Interesse hast.",
-      "playGames": "Spiele spielen"
-    }
+    "greeting": "Hi, ich bin Pascal.",
+    "intro": "Ich arbeite in der Tech-Branche, schreibe über Ideen, die mich beschäftigen, und baue nebenbei kleine, nützliche Dinge. Hier lebt ein Teil davon.",
+    "cta": "Du kannst meine <writing>Texte lesen</writing>, dir den <code>Code anschauen</code>, ein <games>Spiel spielen</games> oder mir <follow>online folgen</follow>. <reachOut>Schreib mir</reachOut> jederzeit."
   },
   "nav": {
     "menu": "Menü",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,20 +1,8 @@
 {
   "home": {
-    "intro": "I'm a developer and writer. I work at Deloitte as a consultant for Data Engineering and AI Engineering with a strong focus on Databricks. Previously, I was an AI Engineer at Deutsche Bundesbank.",
-    "mission": "My life's work is [your mission]. I'm passionate about [interests].",
-    "personal": "I'm a [personal details]. I last listened to [Song] by [Artist].",
-    "cta": {
-      "prefix": "You can read my",
-      "writing": "writing",
-      "or": "or",
-      "code": "code",
-      "comma": ", or",
-      "follow": "follow me online",
-      "period": ".",
-      "reachOut": "Reach out",
-      "suffix": " if interested.",
-      "playGames": "play some games"
-    }
+    "greeting": "Hi, I'm Pascal.",
+    "intro": "I work in tech, write about ideas worth exploring, and build small useful things on the side. This site is where some of that lives.",
+    "cta": "You can read my <writing>writing</writing>, browse the <code>code</code>, <games>play a game</games>, or <follow>follow along</follow>. <reachOut>Reach out</reachOut> anytime."
   },
   "nav": {
     "menu": "Menu",


### PR DESCRIPTION
## Summary

Swaps the site's warm-craftsman design language for a brutalist mono character. Both themes share one identity now; only luminance flips.

**Visual changes** (`app/globals.css`)
- Surfaces: pure white / near-black (no warm tint)
- Type: JetBrains Mono across `--font-sans`, `--font-serif`, `--font-mono`; body defaults to 15px / weight 500
- Shape: `--radius: 0`; extended `@theme inline` so every `rounded-*` utility (xs through 4xl) resolves to the radius token
- Shadows: hard offset (`Npx Npx 0 0 var(--foreground)`), no blur, no opacity
- Borders: `@layer utilities` raises Tailwind's `.border` and side-borders to 2px; `--border` set to the foreground color
- Density: `--spacing: 0.213rem` (~85% of comfortable), `--tracking-normal: 0em`
- Accent: teal (`oklch(0.6 0.15 175)` / `oklch(0.72 0.15 175)` in dark)

**Copy + page**
- New home greeting + simpler intro
- CTA paragraph migrated from segmented translation keys to a single `t.rich()` string with inline link components
- EN and DE translations updated; old `mission`/`personal` placeholder keys removed

**Docs**
- ADR-002 updated to describe the brutalist character, hard-offset shadows, all-mono type, and the default-border-width override

**Tooling**
- `.gitignore` excludes `*.playground.html` (local design tools)

## Test plan

- [ ] `bun run check` clean
- [ ] `bun run build` succeeds
- [ ] `/en` home renders new copy with working links to blog, GitHub, games, X, mailto
- [ ] `/de` home renders translated copy
- [ ] `/en/games` and `/en/tools` cards render with 0 radius
- [ ] Theme toggle flips light / dark cleanly, character stays consistent
- [ ] Cards, buttons, header all sharp-cornered with 2px borders
- [ ] Hard-offset shadows visible on shadowed elements (e.g. dropdown)